### PR TITLE
Upgrade Fedify to 1.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Version 0.3.0
 To be released.
 
  -  Added `MemoryCachedRepository` class.
+ -  Upgraded Fedify to 1.6.1.
 
 
 Version 0.2.0

--- a/deno.json
+++ b/deno.json
@@ -18,7 +18,7 @@
     "./text": "./src/text.ts"
   },
   "imports": {
-    "@fedify/fedify": "jsr:@fedify/fedify@^1.5.1",
+    "@fedify/fedify": "jsr:@fedify/fedify@^1.6.1",
     "@fedify/markdown-it-hashtag": "jsr:@fedify/markdown-it-hashtag@^0.3.0",
     "@fedify/markdown-it-mention": "jsr:@fedify/markdown-it-mention@^0.3.0",
     "@hongminhee/x-forwarded-fetch": "jsr:@hongminhee/x-forwarded-fetch@^0.2.0",


### PR DESCRIPTION
Since Fedify 1.6.1, it started to support Cloudflare Workers. So I hope BotKit also become able to use with Cloudflare Workers.

https://github.com/fedify-dev/fedify/blob/622ae2905f1bb0dbc5893434042119285506d8fc/CHANGES.md?plain=1#L45