### PR TITLE
Allow several environment variables when running `deno test`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -50,7 +50,7 @@
   "tasks": {
     "embed-css": "deno run -A jsr:@smallweb/embed src/css src/static",
     "check": "deno check src/ && deno lint && deno fmt --check && deno publish --dry-run --allow-dirty",
-    "test": "deno test --allow-net=hollo.social --parallel",
+    "test": "deno test --allow-env=NODE_V8_COVERAGE,JEST_WORKER_ID --allow-net=hollo.social --parallel",
     "test-all": "deno task check && deno task test",
     "coverage": "deno task test --coverage --clean && deno coverage --html",
     "hooks:install": "deno run --allow-read=deno.json,.git/hooks/ --allow-write=.git/hooks/ jsr:@hongminhee/deno-task-hooks",


### PR DESCRIPTION
Since #5, it started to fail with the following message when running `deno task test`:

```
error: (in promise) NotCapable: Requires env access to "NODE_V8_COVERAGE", run again with the --allow-env flag
```

Actually, it wasn't caused by the aforementioned PR, but I opened it up because `--allow-env` will let me get away with it.