### PR TITLE
feat: add frontend followers

### DIFF
--- a/packages/botkit/src/components/Follower.tsx
+++ b/packages/botkit/src/components/Follower.tsx
@@ -1,0 +1,67 @@
+// BotKit by Fedify: A framework for creating ActivityPub bots
+// Copyright (C) 2025 Hong Minhee <https://hongminhee.org/>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/** @jsx react-jsx */
+/** @jsxImportSource hono/jsx */
+import { type Actor, getActorHandle, Link } from "@fedify/fedify/vocab";
+import type { Session } from "../session.ts";
+
+export interface FollowerProps {
+  readonly actor: Actor;
+  readonly session: Session<unknown>;
+}
+
+export async function Follower({ actor, session }: FollowerProps) {
+  const { context } = session;
+  const author = actor;
+  const authorIcon = await actor?.getIcon({
+    documentLoader: context.documentLoader,
+    contextLoader: context.contextLoader,
+    suppressError: true,
+  });
+  const authorHandle = await getActorHandle(author);
+
+  return (
+    <article>
+      <header>
+        {author?.id
+          ? (
+            <hgroup>
+              {authorIcon?.url && (
+                <img
+                  src={authorIcon.url instanceof Link
+                    ? authorIcon.url.href?.href
+                    : authorIcon.url.href}
+                  width={authorIcon.width ?? undefined}
+                  height={authorIcon.height ?? undefined}
+                  alt={authorIcon.name?.toString() ?? undefined}
+                  style="float: left; margin-right: 1em; height: 64px;"
+                />
+              )}
+              <h3>
+                <a href={author.url?.href?.toString() ?? author.id.href}>
+                  {author.name}
+                </a>
+              </h3>{" "}
+              <p>
+                <span style="user-select: all;">{authorHandle}</span>
+              </p>
+            </hgroup>
+          )
+          : <em>(Deleted account)</em>}
+      </header>
+    </article>
+  );
+}

--- a/packages/botkit/src/pages.tsx
+++ b/packages/botkit/src/pages.tsx
@@ -237,7 +237,11 @@ app.get("/followers", async (c) => {
       </header>
       <main class="container">
         {followers.map((follower, index) => (
-          <Follower key={follower.id?.href ?? index} actor={follower} session={session} />
+          <Follower
+            key={follower.id?.href ?? index}
+            actor={follower}
+            session={session}
+          />
         ))}
       </main>
     </Layout>,


### PR DESCRIPTION
## Summary

Add `/followers` pages.

## Related Issue

- closes #2

## Changes
- Add `/followers` routes
- Add `Follower` Component


## Benefits

<img width="1920" height="947" alt="Screenshot 2025-08-27 at 18-24-16 Greet Bot (@greetbot@7c70da0646e4b6 lhr life)" src="https://github.com/user-attachments/assets/aef3cd5e-14b2-4378-b390-1c3cf02e714a" />

- Now we can see followers of bots in one page

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?

## Additional Notes

Include any other information, context, or considerations.
