### PR TITLE
Inbound FEP-044f quote authorization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,7 +48,7 @@ To be released.
     at the root.
 
  -  Added inbound support for consent-respecting quote posts using
-    [FEP-044f].  [[#27], [#28], [#31]]
+    [FEP-044f].  [[#27]] [[#28]] [[#31]]
 
     BotKit now serializes quote policies on outgoing messages, handles
     incoming `QuoteRequest` activities, automatically accepts or rejects them
@@ -59,15 +59,17 @@ To be released.
     requests with the new `Bot.onQuoteRequest` event handler.
 
      -  Added `QuotePolicy`, `QuotePolicyOption`, `QuoteRequest`, and
-        `QuoteRequestEventHandler` types.
-     -  Added `Bot.onQuoteRequest` event handler.
+        `QuoteRequestEventHandler` types.  [[#27]] [[#28]] [[#31]]
+     -  Added `Bot.onQuoteRequest` event handler.  [[#27]] [[#28]] [[#31]]
      -  Added `ReadonlyBot.quotePolicy`, `CreateBotOptions.quotePolicy`, and
-        `BotProfile.quotePolicy` properties.
+        `BotProfile.quotePolicy` properties.  [[#27]] [[#28]] [[#31]]
      -  Added `SessionPublishOptions.quotePolicy` and
-        `AuthorizedMessageUpdateOptions.quotePolicy` options.
+        `AuthorizedMessageUpdateOptions.quotePolicy` options.  [[#27]]
+        [[#28]] [[#31]]
      -  Added `AuthorizedMessage.unauthorizeQuote()` method for revoking an
         existing quote authorization stamp by the quoted message or its URI.
-     -  Added `@fedify/botkit/quote` module.
+        [[#27]] [[#28]] [[#31]]
+     -  Added `@fedify/botkit/quote` module.  [[#27]] [[#28]] [[#31]]
 
  -  The `Repository` interface now stores data for multiple bot actors:
     every method takes the identifier of the owning bot actor as its first
@@ -122,7 +124,7 @@ To be released.
 ### @fedify/botkit-sqlite
 
  -  Added a `quote_authorizations` table for [FEP-044f] quote authorization
-    stamps.  [[#27], [#28], [#31]]
+    stamps.  [[#27]] [[#28]] [[#31]]
 
  -  All tables now have a `bot_id` column and composite primary keys, so
     a single database stores the data of multiple bots.  Opening a database
@@ -136,7 +138,7 @@ To be released.
 ### @fedify/botkit-postgres
 
  -  Added a `quote_authorizations` table for [FEP-044f] quote authorization
-    stamps.  [[#27], [#28], [#31]]
+    stamps.  [[#27]] [[#28]] [[#31]]
 
  -  All tables now have a `bot_id` column and composite primary keys, so
     a single schema stores the data of multiple bots.  Initializing a schema

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,28 @@ To be released.
     deployments and preserves their behavior, including the web pages served
     at the root.
 
+ -  Added inbound support for consent-respecting quote posts using
+    [FEP-044f].  [[#27], [#28], [#31]]
+
+    BotKit now serializes quote policies on outgoing messages, handles
+    incoming `QuoteRequest` activities, automatically accepts or rejects them
+    according to each message's policy, and stores `QuoteAuthorization` stamps
+    for accepted quotes.  Applications can set a default
+    `CreateBotOptions.quotePolicy`, override it per message with
+    `Session.publish()` or `AuthorizedMessage.update()`, and moderate pending
+    requests with the new `Bot.onQuoteRequest` event handler.
+
+     -  Added `QuotePolicy`, `QuotePolicyOption`, `QuoteRequest`, and
+        `QuoteRequestEventHandler` types.
+     -  Added `Bot.onQuoteRequest` event handler.
+     -  Added `ReadonlyBot.quotePolicy`, `CreateBotOptions.quotePolicy`, and
+        `BotProfile.quotePolicy` properties.
+     -  Added `SessionPublishOptions.quotePolicy` and
+        `AuthorizedMessageUpdateOptions.quotePolicy` options.
+     -  Added `AuthorizedMessage.unauthorizeQuote()` method for revoking an
+        existing quote authorization stamp by the quoted message or its URI.
+     -  Added `@fedify/botkit/quote` module.
+
  -  The `Repository` interface now stores data for multiple bot actors:
     every method takes the identifier of the owning bot actor as its first
     parameter, and data belonging to different identifiers are isolated from
@@ -56,6 +78,11 @@ To be released.
      -  Added `identifier` parameter to all `Repository` methods.
      -  Added `Repository.findFollowedBots()` method, a reverse lookup
         answering which bots follow a given actor.
+     -  Added quote authorization storage methods:
+        `Repository.addQuoteAuthorization()`,
+        `Repository.getQuoteAuthorization()`,
+        `Repository.findQuoteAuthorization()`, and
+        `Repository.removeQuoteAuthorization()`.
      -  Added optional `Repository.migrate()` method for adopting data
         stored by BotKit 0.4 or earlier.
      -  Added `Repository.forIdentifier()` method and `ActorScopedRepository`
@@ -85,10 +112,17 @@ To be released.
  -  Upgraded Fedify to 2.3.1, Hono to 4.12.27, LogTape to 2.2.3,
     and Markdown It to 14.3.0.
 
+[FEP-044f]: https://w3id.org/fep/044f
 [#16]: https://github.com/fedify-dev/botkit/issues/16
 [#24]: https://github.com/fedify-dev/botkit/pull/24
+[#27]: https://github.com/fedify-dev/botkit/issues/27
+[#28]: https://github.com/fedify-dev/botkit/issues/28
+[#31]: https://github.com/fedify-dev/botkit/pull/31
 
 ### @fedify/botkit-sqlite
+
+ -  Added a `quote_authorizations` table for [FEP-044f] quote authorization
+    stamps.  [[#27], [#28], [#31]]
 
  -  All tables now have a `bot_id` column and composite primary keys, so
     a single database stores the data of multiple bots.  Opening a database
@@ -100,6 +134,9 @@ To be released.
  -  Upgraded Fedify to 2.3.1 and LogTape to 2.2.3.
 
 ### @fedify/botkit-postgres
+
+ -  Added a `quote_authorizations` table for [FEP-044f] quote authorization
+    stamps.  [[#27], [#28], [#31]]
 
  -  All tables now have a `bot_id` column and composite primary keys, so
     a single schema stores the data of multiple bots.  Initializing a schema

--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
     "jsr:@fedify/markdown-it-mention@0.3": "0.3.0",
     "jsr:@fedify/uri-template@^2.3.1": "2.3.1",
     "jsr:@fedify/vocab-runtime@^2.3.1": "2.3.1",
+    "jsr:@fedify/vocab@2.3.1": "2.3.1",
     "jsr:@fedify/vocab@^2.3.1": "2.3.1",
     "jsr:@fedify/webfinger@^2.3.1": "2.3.1",
     "jsr:@hongminhee/x-forwarded-fetch@0.2": "0.2.0",

--- a/docs/concepts/bot.md
+++ b/docs/concepts/bot.md
@@ -226,6 +226,51 @@ It can be changed after the bot is federated.
 > or `FollowRequest.reject()` in the [`Bot.onFollow`](./events.md#follow) event
 > handler.
 
+### `~CreateBotOptions.quotePolicy`
+
+Who can quote messages published by the bot by default.  BotKit serializes the
+policy into each outgoing message and uses it as the fallback for older stored
+messages that do not have a quote policy yet.
+
+The shorthand values are:
+
+`"public"` (default)
+:   Accept every quote request automatically.
+
+`"followers"`
+:   Accept quote requests from followers automatically.
+
+`"manual"`
+:   Leave every quote request pending for the
+    [`Bot.onQuoteRequest`](./events.md#quote-request) event handler.
+
+`"nobody"`
+:   Reject every quote request except the bot's own requests.
+
+You can also use the full two-axis policy object:
+
+~~~~ typescript twoslash
+import type { KvStore } from "@fedify/fedify";
+
+declare const kv: KvStore;
+// ---cut-before---
+import { createBot } from "@fedify/botkit";
+
+const bot = createBot({
+  username: "mybot",
+  name: "My Bot",
+  kv,
+  quotePolicy: {
+    automatic: "followers",
+    manual: "public",
+  },
+});
+~~~~
+
+This accepts followers automatically and sends other quote requests to
+`Bot.onQuoteRequest` for manual moderation.  A publish call can override the
+default with `Session.publish()`'s `quotePolicy` option.
+
 ### `~CreateBotOptions.queue`
 
 The message queue for handling incoming and outgoing activities.  If omitted,

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -265,6 +265,54 @@ property.  See also the [*Quotes* section](./message.md#quotes) in the *Message*
 concept document.
 
 
+Quote request
+-------------
+
+*This API is available since BotKit 0.5.0.*
+
+The `~Bot.onQuoteRequest` event handler is called when a remote actor asks
+permission to quote one of your bot's messages through [FEP-044f].  It
+receives a `QuoteRequest` object, whose `quote` property is the remote quote
+post and whose `target` property is the bot's quoted message.
+
+If the message's quote policy automatically accepts or rejects the request,
+BotKit sends the response before the event handler is called.  The handler can
+inspect `~QuoteRequest.state` to see whether the request is still pending:
+
+~~~~ typescript twoslash
+import { type Bot } from "@fedify/botkit";
+const bot = {} as unknown as Bot<void>;
+// ---cut-before---
+bot.onQuoteRequest = async (session, request) => {
+  if (request.state === "pending") {
+    await request.accept();
+  }
+};
+~~~~
+
+If you later need to revoke a quote authorization, call
+`~AuthorizedMessage.unauthorizeQuote()` on the target message with the quote
+message:
+
+~~~~ typescript twoslash
+import { type Bot } from "@fedify/botkit";
+const bot = {} as unknown as Bot<void>;
+// ---cut-before---
+bot.onQuoteRequest = async (session, request) => {
+  if (request.state === "accepted") {
+    await request.target.unauthorizeQuote(request.quote);
+  }
+};
+~~~~
+
+Use the `quotePolicy` option on `createBot()` or `Session.publish()` to choose
+which quote requests are automatic and which require manual review.  For
+details, see the [*Quote policy* section](./message.md#quote-policy) in
+the *Message* concept document.
+
+[FEP-044f]: https://w3id.org/fep/044f
+
+
 Message
 -------
 

--- a/docs/concepts/message.md
+++ b/docs/concepts/message.md
@@ -158,6 +158,73 @@ await session.publish(text`Hello, ${mention("@fedify@hollo.social")}!`, {
 });
 ~~~~
 
+### Quote policy
+
+You can control who may quote a message by providing
+`~SessionPublishOptions.quotePolicy`.  BotKit serializes this policy as
+the [FEP-044f] interaction policy on the ActivityPub object and uses it when
+answering incoming quote requests.
+
+The shorthand values are:
+
+`"public"`
+:   Anyone may quote the message.  This is the default.
+
+`"followers"`
+:   Followers may quote the message automatically.
+
+`"nobody"`
+:   Nobody may quote the message, except the bot itself.
+
+`"manual"`
+:   Quote requests are left pending for `~Bot.onQuoteRequest`.
+
+~~~~ typescript twoslash
+import { type Session, text } from "@fedify/botkit";
+const session = {} as unknown as Session<void>;
+// ---cut-before---
+await session.publish(text`Followers can quote this.`, {
+  quotePolicy: "followers",
+});
+~~~~
+
+You can also use the two-axis form to distinguish actors whose quotes are
+approved automatically from actors whose quotes await manual review:
+
+~~~~ typescript twoslash
+import { type Session, text } from "@fedify/botkit";
+const session = {} as unknown as Session<void>;
+// ---cut-before---
+await session.publish(text`Followers are reviewed before quoting this.`, {
+  quotePolicy: { manual: "followers" },
+});
+~~~~
+
+The quote policy can be changed when editing a message:
+
+~~~~ typescript twoslash
+import { type Session, text } from "@fedify/botkit";
+const session = {} as unknown as Session<void>;
+// ---cut-before---
+const message = await session.publish(text`This starts public.`);
+await message.update(text`This is now harder to quote.`, {
+  quotePolicy: "nobody",
+});
+~~~~
+
+If a quote was already authorized through an incoming quote request, you can
+revoke its authorization stamp from the quoted message:
+
+~~~~ typescript twoslash
+import { type AuthorizedMessage, type Message, type MessageClass } from "@fedify/botkit";
+declare const message: AuthorizedMessage<MessageClass, void>;
+declare const quote: Message<MessageClass, void>;
+// ---cut-before---
+await message.unauthorizeQuote(quote);
+~~~~
+
+[FEP-044f]: https://w3id.org/fep/044f
+
 ### Attaching media
 
 You can attach media files to a message by providing

--- a/packages/botkit-postgres/src/mod.test.ts
+++ b/packages/botkit-postgres/src/mod.test.ts
@@ -219,6 +219,13 @@ if (postgresUrl == null) {
     test("does not emit unhandled rejections for schema initialization", async () => {
       const error = new Error("Schema initialization failed.");
       const sql = {
+        begin: async (
+          callback: (
+            transactionSql: { unsafe: () => Promise<never> },
+          ) => Promise<void>,
+        ) => {
+          await callback(sql);
+        },
         // deno-lint-ignore require-await
         unsafe: async () => {
           throw error;

--- a/packages/botkit-postgres/src/mod.test.ts
+++ b/packages/botkit-postgres/src/mod.test.ts
@@ -18,7 +18,14 @@ import {
   PostgresRepository,
 } from "@fedify/botkit-postgres";
 import { importJwk } from "@fedify/fedify/sig";
-import { Create, Follow, Note, Person, PUBLIC_COLLECTION } from "@fedify/vocab";
+import {
+  Create,
+  Follow,
+  Note,
+  Person,
+  PUBLIC_COLLECTION,
+  QuoteAuthorization,
+} from "@fedify/vocab";
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import postgres from "postgres";
@@ -129,6 +136,7 @@ if (postgresUrl == null) {
             "key_pairs",
             "messages",
             "poll_votes",
+            "quote_authorizations",
             "sent_follows",
           ],
         );
@@ -1025,6 +1033,47 @@ if (postgresUrl == null) {
       } finally {
         await sql.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
         await sql.end();
+      }
+    });
+
+    test("keeps the first quote authorization for a quote", async () => {
+      const harness = createHarness();
+      try {
+        const repo = harness.repository;
+        const firstId = "01942976-3400-7f34-872e-2cbf0f9eeac4";
+        const secondId = "01942976-3400-7f34-872e-2cbf0f9eeac5";
+        const quote = new URL("https://remote.example/notes/quote");
+        const target = new URL("https://example.com/ap/note/1");
+        const first = new QuoteAuthorization({
+          id: new URL(
+            `https://example.com/ap/actor/bot/quote-authorization/${firstId}`,
+          ),
+          attribution: new URL("https://example.com/ap/actor/bot"),
+          interactingObject: quote,
+          interactionTarget: target,
+        });
+        const second = new QuoteAuthorization({
+          id: new URL(
+            `https://example.com/ap/actor/bot/quote-authorization/${secondId}`,
+          ),
+          attribution: new URL("https://example.com/ap/actor/bot"),
+          interactingObject: quote,
+          interactionTarget: target,
+        });
+
+        await repo.addQuoteAuthorization("bot", firstId, first);
+        await repo.addQuoteAuthorization("bot", secondId, second);
+
+        assert.deepStrictEqual(
+          (await repo.findQuoteAuthorization("bot", quote))?.id?.href,
+          first.id?.href,
+        );
+        assert.deepStrictEqual(
+          await repo.getQuoteAuthorization("bot", secondId),
+          undefined,
+        );
+      } finally {
+        await harness.cleanup();
       }
     });
   });

--- a/packages/botkit-postgres/src/mod.ts
+++ b/packages/botkit-postgres/src/mod.ts
@@ -130,26 +130,23 @@ export type PostgresRepositoryOptions =
  * @since 0.4.0
  */
 export async function initializePostgresRepositorySchema(
-  sql: Queryable,
+  sql: TransactionalQueryable,
   schema = "botkit",
   prepare = true,
 ): Promise<void> {
   const validatedSchema = validateSchemaName(schema);
-  if (hasTransaction(sql)) {
-    await sql.begin(async (tx) => {
-      await initializePostgresRepositorySchemaInTransaction(
-        tx,
-        validatedSchema,
-        prepare,
-      );
-    });
-    return;
+  if (!hasTransaction(sql)) {
+    throw new TypeError(
+      "The PostgreSQL client must support transactions.",
+    );
   }
-  await initializePostgresRepositorySchemaInTransaction(
-    sql,
-    validatedSchema,
-    prepare,
-  );
+  await sql.begin(async (tx) => {
+    await initializePostgresRepositorySchemaInTransaction(
+      tx,
+      validatedSchema,
+      prepare,
+    );
+  });
 }
 
 async function initializePostgresRepositorySchemaInTransaction(

--- a/packages/botkit-postgres/src/mod.ts
+++ b/packages/botkit-postgres/src/mod.ts
@@ -1285,7 +1285,8 @@ function validateSchemaName(schema: string): string {
 }
 
 function hasTransaction(sql: Queryable): sql is TransactionalQueryable {
-  return typeof (sql as Partial<TransactionalQueryable>).begin === "function";
+  return sql != null &&
+    typeof (sql as Partial<TransactionalQueryable>).begin === "function";
 }
 
 async function execute<TRow extends object>(

--- a/packages/botkit-postgres/src/mod.ts
+++ b/packages/botkit-postgres/src/mod.ts
@@ -30,6 +30,7 @@ import {
   Follow,
   isActor,
   Object,
+  QuoteAuthorization,
 } from "@fedify/vocab";
 import { getLogger } from "@logtape/logtape";
 import postgres from "postgres";
@@ -48,6 +49,7 @@ const followerAdvisoryLockNamespace = 0x4246;
 const schemaUpgradeAdvisoryLockNamespace = 0x424b;
 
 type Queryable = Pick<postgres.Sql, "unsafe">;
+type TransactionalQueryable = Queryable & Pick<postgres.Sql, "begin">;
 type QueryParameter = postgres.SerializableParameter;
 
 /**
@@ -133,6 +135,37 @@ export async function initializePostgresRepositorySchema(
   prepare = true,
 ): Promise<void> {
   const validatedSchema = validateSchemaName(schema);
+  if (hasTransaction(sql)) {
+    await sql.begin(async (tx) => {
+      await initializePostgresRepositorySchemaInTransaction(
+        tx,
+        validatedSchema,
+        prepare,
+      );
+    });
+    return;
+  }
+  await initializePostgresRepositorySchemaInTransaction(
+    sql,
+    validatedSchema,
+    prepare,
+  );
+}
+
+async function initializePostgresRepositorySchemaInTransaction(
+  sql: Queryable,
+  validatedSchema: string,
+  prepare: boolean,
+): Promise<void> {
+  await execute(
+    sql,
+    `SELECT pg_catalog.pg_advisory_xact_lock(
+       $1,
+       pg_catalog.hashtext($2)
+     )`,
+    [schemaUpgradeAdvisoryLockNamespace, validatedSchema],
+    prepare,
+  );
   await execute(
     sql,
     `CREATE SCHEMA IF NOT EXISTS "${validatedSchema}"`,
@@ -244,6 +277,19 @@ export async function initializePostgresRepositorySchema(
   );
   await execute(
     sql,
+    `CREATE TABLE IF NOT EXISTS "${validatedSchema}"."quote_authorizations" (
+       bot_id TEXT NOT NULL,
+       id TEXT NOT NULL,
+       interacting_object TEXT NOT NULL,
+       authorization_json JSONB NOT NULL,
+       PRIMARY KEY (bot_id, id),
+       UNIQUE (bot_id, interacting_object)
+     )`,
+    [],
+    prepare,
+  );
+  await execute(
+    sql,
     `CREATE TABLE IF NOT EXISTS "${validatedSchema}"."poll_votes" (
        bot_id TEXT NOT NULL,
        message_id TEXT NOT NULL,
@@ -270,6 +316,7 @@ const upgradableTables = [
   "follow_requests",
   "sent_follows",
   "followees",
+  "quote_authorizations",
   "poll_votes",
 ] as const;
 
@@ -410,6 +457,20 @@ async function upgradeLegacySchema(
           DROP CONSTRAINT IF EXISTS "followees_pkey";
         ALTER TABLE "${schema}"."followees"
           ADD PRIMARY KEY (bot_id, followee_id);
+        upgraded := true;
+      END IF;
+
+      IF ${legacyTable("quote_authorizations")} THEN
+        ALTER TABLE "${schema}"."quote_authorizations"
+          ADD COLUMN bot_id TEXT NOT NULL DEFAULT '';
+        ALTER TABLE "${schema}"."quote_authorizations"
+          ALTER COLUMN bot_id DROP DEFAULT;
+        ALTER TABLE "${schema}"."quote_authorizations"
+          DROP CONSTRAINT IF EXISTS "quote_authorizations_pkey";
+        ALTER TABLE "${schema}"."quote_authorizations"
+          ADD PRIMARY KEY (bot_id, id);
+        ALTER TABLE "${schema}"."quote_authorizations"
+          ADD UNIQUE (bot_id, interacting_object);
         upgraded := true;
       END IF;
 
@@ -964,6 +1025,78 @@ export class PostgresRepository implements Repository, AsyncDisposable {
     for (const row of rows) yield row.bot_id;
   }
 
+  async addQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+    authorization: QuoteAuthorization,
+  ): Promise<void> {
+    await this.ensureReady();
+    const interactingObject = authorization.interactingObjectId;
+    if (interactingObject == null) {
+      throw new TypeError(
+        "The quote authorization interacting object is missing.",
+      );
+    }
+    await this.query(
+      this.sql,
+      `INSERT INTO ${this.table("quote_authorizations")}
+         (bot_id, id, interacting_object, authorization_json)
+       VALUES ($1, $2, $3, $4::jsonb)
+       ON CONFLICT (bot_id, interacting_object) DO NOTHING`,
+      [
+        identifier,
+        id,
+        interactingObject.href,
+        serializeJson(await authorization.toJsonLd({ format: "compact" })),
+      ],
+    );
+  }
+
+  async getQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    await this.ensureReady();
+    const rows = await this.query<{ readonly authorization_json: unknown }>(
+      this.sql,
+      `SELECT authorization_json
+         FROM ${this.table("quote_authorizations")}
+        WHERE bot_id = $1 AND id = $2`,
+      [identifier, id],
+    );
+    return await parseQuoteAuthorization(rows[0]?.authorization_json);
+  }
+
+  async findQuoteAuthorization(
+    identifier: string,
+    interactingObject: URL,
+  ): Promise<QuoteAuthorization | undefined> {
+    await this.ensureReady();
+    const rows = await this.query<{ readonly authorization_json: unknown }>(
+      this.sql,
+      `SELECT authorization_json
+         FROM ${this.table("quote_authorizations")}
+        WHERE bot_id = $1 AND interacting_object = $2`,
+      [identifier, interactingObject.href],
+    );
+    return await parseQuoteAuthorization(rows[0]?.authorization_json);
+  }
+
+  async removeQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    await this.ensureReady();
+    const rows = await this.query<{ readonly authorization_json: unknown }>(
+      this.sql,
+      `DELETE FROM ${this.table("quote_authorizations")}
+        WHERE bot_id = $1 AND id = $2
+    RETURNING authorization_json`,
+      [identifier, id],
+    );
+    return await parseQuoteAuthorization(rows[0]?.authorization_json);
+  }
+
   async vote(
     identifier: string,
     messageId: Uuid,
@@ -1154,6 +1287,10 @@ function validateSchemaName(schema: string): string {
   return schema;
 }
 
+function hasTransaction(sql: Queryable): sql is TransactionalQueryable {
+  return typeof (sql as Partial<TransactionalQueryable>).begin === "function";
+}
+
 async function execute<TRow extends object>(
   sql: Queryable,
   query: string,
@@ -1210,6 +1347,19 @@ async function parseFollow(json: unknown): Promise<Follow | undefined> {
     return await Follow.fromJsonLd(normalized);
   } catch (error) {
     logger.warn("Failed to parse follow activity.", { error });
+  }
+  return undefined;
+}
+
+async function parseQuoteAuthorization(
+  json: unknown,
+): Promise<QuoteAuthorization | undefined> {
+  const normalized = normalizeJsonObject(json);
+  if (normalized == null) return undefined;
+  try {
+    return await QuoteAuthorization.fromJsonLd(normalized);
+  } catch (error) {
+    logger.warn("Failed to parse quote authorization.", { error });
   }
   return undefined;
 }

--- a/packages/botkit-sqlite/src/mod.test.ts
+++ b/packages/botkit-sqlite/src/mod.test.ts
@@ -370,6 +370,49 @@ describe("SqliteRepository", () => {
     }
   });
 
+  test("removes quote authorization rows before parsing", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "botkit_sqlite_test_"));
+    const dbPath = `${tempDir}/test.db`;
+    const repo = createSqliteRepository({ path: dbPath });
+    repo.close();
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.prepare(`
+        INSERT INTO quote_authorizations
+          (bot_id, id, interacting_object, authorization_json)
+        VALUES (?, ?, ?, ?)
+      `).run(
+        "bot",
+        "01942976-3400-7f34-872e-2cbf0f9eeac4",
+        "https://remote.example/notes/quote",
+        "{",
+      );
+    } finally {
+      db.close();
+    }
+
+    const reopened = createSqliteRepository({ path: dbPath });
+    try {
+      assert.deepStrictEqual(
+        await reopened.removeQuoteAuthorization(
+          "bot",
+          "01942976-3400-7f34-872e-2cbf0f9eeac4",
+        ),
+        undefined,
+      );
+      assert.deepStrictEqual(
+        await reopened.findQuoteAuthorization(
+          "bot",
+          new URL("https://remote.example/notes/quote"),
+        ),
+        undefined,
+      );
+    } finally {
+      reopened.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("file-based database persistence", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "botkit_sqlite_test_"));
     const dbPath = `${tempDir}/test.db`;

--- a/packages/botkit-sqlite/src/mod.test.ts
+++ b/packages/botkit-sqlite/src/mod.test.ts
@@ -18,7 +18,14 @@ import {
   type SqliteRepositoryOptions,
 } from "@fedify/botkit-sqlite";
 import { importJwk } from "@fedify/fedify/sig";
-import { Create, Follow, Note, Person, PUBLIC_COLLECTION } from "@fedify/vocab";
+import {
+  Create,
+  Follow,
+  Note,
+  Person,
+  PUBLIC_COLLECTION,
+  QuoteAuthorization,
+} from "@fedify/vocab";
 import assert from "node:assert";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -318,6 +325,46 @@ describe("SqliteRepository", () => {
         "option1": 2,
         "option2": 1,
       });
+    } finally {
+      repo.close();
+    }
+  });
+
+  test("keeps the first quote authorization for a quote", async () => {
+    const repo = createSqliteRepository();
+    try {
+      const firstId = "01942976-3400-7f34-872e-2cbf0f9eeac4";
+      const secondId = "01942976-3400-7f34-872e-2cbf0f9eeac5";
+      const quote = new URL("https://remote.example/notes/quote");
+      const target = new URL("https://example.com/ap/note/1");
+      const first = new QuoteAuthorization({
+        id: new URL(
+          `https://example.com/ap/actor/bot/quote-authorization/${firstId}`,
+        ),
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        interactingObject: quote,
+        interactionTarget: target,
+      });
+      const second = new QuoteAuthorization({
+        id: new URL(
+          `https://example.com/ap/actor/bot/quote-authorization/${secondId}`,
+        ),
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        interactingObject: quote,
+        interactionTarget: target,
+      });
+
+      await repo.addQuoteAuthorization("bot", firstId, first);
+      await repo.addQuoteAuthorization("bot", secondId, second);
+
+      assert.deepStrictEqual(
+        (await repo.findQuoteAuthorization("bot", quote))?.id?.href,
+        first.id?.href,
+      );
+      assert.deepStrictEqual(
+        await repo.getQuoteAuthorization("bot", secondId),
+        undefined,
+      );
     } finally {
       repo.close();
     }

--- a/packages/botkit-sqlite/src/mod.ts
+++ b/packages/botkit-sqlite/src/mod.ts
@@ -29,6 +29,7 @@ import {
   Follow,
   isActor,
   Object,
+  QuoteAuthorization,
 } from "@fedify/vocab";
 import { getLogger } from "@logtape/logtape";
 import { DatabaseSync } from "node:sqlite";
@@ -122,6 +123,7 @@ export class SqliteRepository implements Repository, Disposable {
       "follow_requests",
       "sent_follows",
       "followees",
+      "quote_authorizations",
       "poll_votes",
     ].filter((table) => this.tableExists(table) && !this.hasBotIdColumn(table));
     if (tables.length < 1) return;
@@ -237,6 +239,28 @@ export class SqliteRepository implements Repository, Disposable {
         this.db.exec("DROP TABLE followees");
         this.db.exec("ALTER TABLE followees_new RENAME TO followees");
       }
+      if (tables.includes("quote_authorizations")) {
+        this.db.exec(`
+          CREATE TABLE quote_authorizations_new (
+            bot_id TEXT NOT NULL,
+            id TEXT NOT NULL,
+            interacting_object TEXT NOT NULL,
+            authorization_json TEXT NOT NULL,
+            PRIMARY KEY (bot_id, id),
+            UNIQUE (bot_id, interacting_object)
+          )
+        `);
+        this.db.exec(`
+          INSERT INTO quote_authorizations_new
+            (bot_id, id, interacting_object, authorization_json)
+          SELECT '', id, interacting_object, authorization_json
+          FROM quote_authorizations
+        `);
+        this.db.exec("DROP TABLE quote_authorizations");
+        this.db.exec(
+          "ALTER TABLE quote_authorizations_new RENAME TO quote_authorizations",
+        );
+      }
       if (tables.includes("poll_votes")) {
         this.db.exec(`
           CREATE TABLE poll_votes_new (
@@ -300,6 +324,7 @@ export class SqliteRepository implements Repository, Disposable {
           "follow_requests",
           "sent_follows",
           "followees",
+          "quote_authorizations",
           "poll_votes",
         ]
       ) {
@@ -401,6 +426,17 @@ export class SqliteRepository implements Repository, Disposable {
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_followees_followee_id
       ON followees(followee_id)
+    `);
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS quote_authorizations (
+        bot_id TEXT NOT NULL,
+        id TEXT NOT NULL,
+        interacting_object TEXT NOT NULL,
+        authorization_json TEXT NOT NULL,
+        PRIMARY KEY (bot_id, id),
+        UNIQUE (bot_id, interacting_object)
+      )
     `);
 
     // Poll votes table
@@ -966,6 +1002,72 @@ export class SqliteRepository implements Repository, Disposable {
     for (const row of rows) yield row.bot_id;
   }
 
+  async addQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+    authorization: QuoteAuthorization,
+  ): Promise<void> {
+    const interactingObject = authorization.interactingObjectId;
+    if (interactingObject == null) {
+      throw new TypeError(
+        "The quote authorization interacting object is missing.",
+      );
+    }
+    const stmt = this.db.prepare(`
+      INSERT INTO quote_authorizations
+        (bot_id, id, interacting_object, authorization_json)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(bot_id, interacting_object) DO NOTHING
+    `);
+    stmt.run(
+      identifier,
+      id,
+      interactingObject.href,
+      JSON.stringify(await authorization.toJsonLd({ format: "compact" })),
+    );
+  }
+
+  async getQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    const stmt = this.db.prepare(`
+      SELECT authorization_json FROM quote_authorizations
+      WHERE bot_id = ? AND id = ?
+    `);
+    const row = stmt.get(identifier, id) as
+      | { authorization_json: string }
+      | undefined;
+    return await parseQuoteAuthorizationJson(row?.authorization_json);
+  }
+
+  async findQuoteAuthorization(
+    identifier: string,
+    interactingObject: URL,
+  ): Promise<QuoteAuthorization | undefined> {
+    const stmt = this.db.prepare(`
+      SELECT authorization_json FROM quote_authorizations
+      WHERE bot_id = ? AND interacting_object = ?
+    `);
+    const row = stmt.get(identifier, interactingObject.href) as
+      | { authorization_json: string }
+      | undefined;
+    return await parseQuoteAuthorizationJson(row?.authorization_json);
+  }
+
+  async removeQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    const authorization = await this.getQuoteAuthorization(identifier, id);
+    if (authorization == null) return undefined;
+    const stmt = this.db.prepare(
+      "DELETE FROM quote_authorizations WHERE bot_id = ? AND id = ?",
+    );
+    stmt.run(identifier, id);
+    return authorization;
+  }
+
   vote(
     identifier: string,
     messageId: Uuid,
@@ -1016,5 +1118,17 @@ export class SqliteRepository implements Repository, Disposable {
 
   forIdentifier(identifier: string): ActorScopedRepository {
     return new ActorScopedRepository(this, identifier);
+  }
+}
+
+async function parseQuoteAuthorizationJson(
+  json: string | undefined,
+): Promise<QuoteAuthorization | undefined> {
+  if (json == null) return undefined;
+  try {
+    return await QuoteAuthorization.fromJsonLd(JSON.parse(json));
+  } catch (error) {
+    logger.warn("Failed to parse quote authorization", { error });
+    return undefined;
   }
 }

--- a/packages/botkit-sqlite/src/mod.ts
+++ b/packages/botkit-sqlite/src/mod.ts
@@ -1059,13 +1059,14 @@ export class SqliteRepository implements Repository, Disposable {
     identifier: string,
     id: Uuid,
   ): Promise<QuoteAuthorization | undefined> {
-    const authorization = await this.getQuoteAuthorization(identifier, id);
-    if (authorization == null) return undefined;
     const stmt = this.db.prepare(
-      "DELETE FROM quote_authorizations WHERE bot_id = ? AND id = ?",
+      "DELETE FROM quote_authorizations WHERE bot_id = ? AND id = ? " +
+        "RETURNING authorization_json",
     );
-    stmt.run(identifier, id);
-    return authorization;
+    const row = stmt.get(identifier, id) as
+      | { authorization_json: string }
+      | undefined;
+    return await parseQuoteAuthorizationJson(row?.authorization_json);
   }
 
   vote(

--- a/packages/botkit/deno.json
+++ b/packages/botkit/deno.json
@@ -11,6 +11,7 @@
     "./instance": "./src/instance.ts",
     "./message": "./src/message.ts",
     "./poll": "./src/poll.ts",
+    "./quote": "./src/quote.ts",
     "./reaction": "./src/reaction.ts",
     "./repository": "./src/repository.ts",
     "./session": "./src/session.ts",

--- a/packages/botkit/package.json
+++ b/packages/botkit/package.json
@@ -62,6 +62,10 @@
       "types": "./dist/poll.d.ts",
       "import": "./dist/poll.js"
     },
+    "./quote": {
+      "types": "./dist/quote.d.ts",
+      "import": "./dist/quote.js"
+    },
     "./reaction": {
       "types": "./dist/reaction.d.ts",
       "import": "./dist/reaction.js"

--- a/packages/botkit/src/bot-group.test.ts
+++ b/packages/botkit/src/bot-group.test.ts
@@ -14,12 +14,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import { type InboxContext, MemoryKvStore } from "@fedify/fedify/federation";
-import { Create, Follow, Note, Person, PUBLIC_COLLECTION } from "@fedify/vocab";
+import {
+  Create,
+  Follow,
+  Note,
+  Person,
+  PUBLIC_COLLECTION,
+  QuoteRequest,
+} from "@fedify/vocab";
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { InstanceImpl } from "./instance-impl.ts";
 import type { BotProfile } from "./instance.ts";
 import { MemoryRepository } from "./repository.ts";
+import { text } from "./text.ts";
 
 function createInstance(): {
   instance: InstanceImpl<void>;
@@ -262,6 +270,60 @@ describe("dynamic bots", () => {
 });
 
 describe("dynamic bots in routing and web pages", () => {
+  test("receive quote requests for their messages", async () => {
+    const { instance, repository } = createInstance();
+    const group = instance.createBot(
+      (_ctx, identifier) => regionProfile(identifier),
+    );
+    const events: string[] = [];
+    group.onQuoteRequest = (session, request) => {
+      events.push(`${session.bot.identifier}:${request.state}`);
+    };
+    const ctx = instance.federation.createContext(
+      new URL("https://example.com/"),
+      undefined,
+    ) as InboxContext<void>;
+    Object.defineProperty(ctx, "recipient", {
+      value: null,
+      configurable: true,
+    });
+    Object.defineProperty(ctx, "sendActivity", {
+      value: () => Promise.resolve(),
+      configurable: true,
+    });
+    const bot = await instance.resolveBot(ctx, "region_kr");
+    assert.ok(bot != null);
+    const target = await bot.getSession(ctx).publish(text`Quote me`);
+    const actor = new Person({
+      id: new URL("https://remote.example/users/alice"),
+      preferredUsername: "alice",
+    });
+    const quote = new Note({
+      id: new URL("https://remote.example/notes/quote"),
+      attribution: actor,
+      quoteUrl: target.id,
+      content: "Quoted.",
+      to: PUBLIC_COLLECTION,
+    });
+
+    await instance.onQuoteRequested(
+      ctx,
+      new QuoteRequest({
+        id: new URL("https://remote.example/quote-requests/1"),
+        actor,
+        object: target.id,
+        instrument: quote,
+      }),
+    );
+
+    assert.deepStrictEqual(events, ["region_kr:accepted"]);
+    assert.deepStrictEqual(
+      (await repository.findQuoteAuthorization("region_kr", quote.id!))
+        ?.interactionTargetId,
+      target.id,
+    );
+  });
+
   test("receive timeline messages via followees", async () => {
     const { instance, repository } = createInstance();
     const group = instance.createBot(

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -29,6 +29,7 @@ import {
   Follow,
   Image,
   Like as RawLike,
+  Link,
   Mention,
   Note,
   Person,
@@ -2090,6 +2091,54 @@ test("BotImpl.onCreated()", async (t) => {
         quote: new URL(
           "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
         ),
+      }),
+    });
+    let quoted: [Session<void>, Message<MessageClass, void>][] = [];
+    bot.onQuote = (session, msg) => void (quoted.push([session, msg]));
+
+    await bot.onCreated(ctx, create);
+
+    assert.deepStrictEqual(quoted, []);
+    assert.deepStrictEqual(replied, []);
+    assert.deepStrictEqual(mentioned, []);
+    assert.deepStrictEqual(messaged.length, 1);
+    assert.deepStrictEqual(ctx.sentActivities, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, []);
+
+    quoted = [];
+    messaged = [];
+    ctx.forwardedRecipients = [];
+  });
+
+  await t.test("on unauthorized FEP quote with fallback link", async () => {
+    const targetId = new URL(
+      "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
+    );
+    const create = new Create({
+      id: new URL(
+        "https://example.com/ap/create/9cfd7129-4cf0-4505-90d8-3cac2dc42436",
+      ),
+      actor: new URL("https://example.com/ap/actor/john"),
+      to: PUBLIC_COLLECTION,
+      cc: new URL("https://example.com/ap/actor/john/followers"),
+      object: new Note({
+        id: new URL(
+          "https://example.com/ap/note/9cfd7129-4cf0-4505-90d8-3cac2dc42436",
+        ),
+        attribution: new Person({
+          id: new URL("https://example.com/ap/actor/john"),
+          preferredUsername: "john",
+        }),
+        to: PUBLIC_COLLECTION,
+        cc: new URL("https://example.com/ap/actor/john/followers"),
+        content: "It's a FEP quote with a fallback link!",
+        quote: targetId,
+        tags: [
+          new Link({
+            href: targetId,
+            mediaType: "application/activity+json",
+          }),
+        ],
       }),
     });
     let quoted: [Session<void>, Message<MessageClass, void>][] = [];

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -2101,7 +2101,7 @@ test("BotImpl.onCreated()", async (t) => {
     assert.deepStrictEqual(quoted, []);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged.length, 1);
+    assert.deepStrictEqual(messaged, []);
     assert.deepStrictEqual(ctx.sentActivities, []);
     assert.deepStrictEqual(ctx.forwardedRecipients, []);
 
@@ -2149,7 +2149,7 @@ test("BotImpl.onCreated()", async (t) => {
     assert.deepStrictEqual(quoted, []);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged.length, 1);
+    assert.deepStrictEqual(messaged, []);
     assert.deepStrictEqual(ctx.sentActivities, []);
     assert.deepStrictEqual(ctx.forwardedRecipients, []);
 
@@ -2383,7 +2383,7 @@ test("BotImpl.onCreated()", async (t) => {
     assert.deepStrictEqual(quoted, []);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged.length, 1);
+    assert.deepStrictEqual(messaged, []);
     assert.deepStrictEqual(ctx.sentActivities, []);
     assert.deepStrictEqual(ctx.forwardedRecipients, []);
 

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3802,6 +3802,73 @@ test("BotImpl.onQuoteRequested() revokes widened quote stamps", async () => {
   assert.ok(ctx.sentActivities[2].activity instanceof Reject);
 });
 
+test("BotImpl.onQuoteRequested() revokes disallowed quote stamps", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "public",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Quote me`);
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quoteId = new URL("https://remote.example/notes/stale-quote");
+  const quote = new Note({
+    id: quoteId,
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted directly.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/old-policy"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quoteId,
+  );
+  assert.ok(authorization != null);
+  await target.update(text`Quote me`, { quotePolicy: "nobody" });
+  ctx.sentActivities = [];
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/new-policy"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quoteId),
+    undefined,
+  );
+  assert.deepStrictEqual(ctx.sentActivities.length, 3);
+  assert.ok(ctx.sentActivities[0].activity instanceof Delete);
+  assert.deepStrictEqual(
+    ctx.sentActivities[0].activity.objectId,
+    authorization.id,
+  );
+  assert.deepStrictEqual(ctx.sentActivities[1].recipients, "followers");
+  assert.ok(ctx.sentActivities[2].activity instanceof Reject);
+});
+
 test("BotImpl.onQuoteRequested() does not accept a raced stamp", async () => {
   class RacedQuoteAuthorizationRepository extends MemoryRepository {
     readonly racedAuthorization: QuoteAuthorization;

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -36,6 +36,7 @@ import {
   PropertyValue,
   PUBLIC_COLLECTION,
   Question,
+  QuoteAuthorization,
   QuoteRequest,
   type Recipient,
   Reject,
@@ -56,7 +57,7 @@ import type {
 } from "./message.ts";
 import type { Vote } from "./poll.ts";
 import type { Like, Reaction } from "./reaction.ts";
-import { MemoryRepository } from "./repository.ts";
+import { MemoryRepository, type Uuid } from "./repository.ts";
 import { SessionImpl } from "./session-impl.ts";
 import type { Session } from "./session.ts";
 import { mention, strong, text } from "./text.ts";
@@ -3607,6 +3608,84 @@ test("BotImpl.onQuoteRequested() revokes widened quote stamps", async () => {
   );
   assert.deepStrictEqual(ctx.sentActivities[1].recipients, "followers");
   assert.ok(ctx.sentActivities[2].activity instanceof Reject);
+});
+
+test("BotImpl.onQuoteRequested() does not accept a raced stamp", async () => {
+  class RacedQuoteAuthorizationRepository extends MemoryRepository {
+    readonly racedAuthorization: QuoteAuthorization;
+
+    constructor(racedAuthorization: QuoteAuthorization) {
+      super();
+      this.racedAuthorization = racedAuthorization;
+    }
+
+    override async addQuoteAuthorization(
+      identifier: string,
+      _id: Uuid,
+      authorization: QuoteAuthorization,
+    ): Promise<void> {
+      const interactingObject = authorization.interactingObjectId;
+      if (interactingObject == null) {
+        throw new TypeError(
+          "The quote authorization interacting object is missing.",
+        );
+      }
+      if (
+        await this.findQuoteAuthorization(identifier, interactingObject) == null
+      ) {
+        await super.addQuoteAuthorization(
+          identifier,
+          "01950000-0000-7000-8000-000000000001" as Uuid,
+          this.racedAuthorization,
+        );
+      }
+    }
+  }
+
+  const racedAuthorization = new QuoteAuthorization({
+    id: new URL("https://example.com/ap/quote-authorization/raced"),
+    attribution: new URL("https://example.com/ap/actor/bot"),
+    interactingObject: new URL("https://remote.example/notes/raced-quote"),
+    interactionTarget: new URL("https://example.com/ap/note/other-target"),
+  });
+  const repository = new RacedQuoteAuthorizationRepository(
+    racedAuthorization,
+  );
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "public",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Quote me`);
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quote = new Note({
+    id: racedAuthorization.interactingObjectId,
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await assert.rejects(
+    bot.onQuoteRequested(
+      ctx,
+      new QuoteRequest({
+        id: new URL("https://remote.example/quote-requests/raced"),
+        actor,
+        object: target.id,
+        instrument: quote,
+      }),
+    ),
+    TypeError,
+  );
+  assert.deepStrictEqual(ctx.sentActivities, []);
 });
 
 test("BotImpl.onQuoteRequested() rejects unknown-audience quotes", async () => {

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3848,6 +3848,68 @@ test("BotImpl.onQuoteRequested() accepts quotes to the target author", async () 
   assert.deepStrictEqual(authorization?.interactionTargetId, target.id);
 });
 
+test("BotImpl.onQuoteRequested() accepts quotes to target followers", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "followers",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Followers only`, {
+    visibility: "followers",
+  });
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const otherFollower = new Person({
+    id: new URL("https://remote.example/users/bob"),
+    preferredUsername: "bob",
+  });
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow/alice"),
+    actor,
+  );
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow/bob"),
+    otherFollower,
+  );
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/follower-only-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted to another follower.",
+    to: otherFollower.id,
+    tags: [new Mention({ href: otherFollower.id })],
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/other-follower"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Accept);
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quote.id!,
+  );
+  assert.deepStrictEqual(authorization?.interactionTargetId, target.id);
+});
+
 test("BotImpl.onQuoteRequested() revokes widened quote stamps", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3486,6 +3486,57 @@ test("BotImpl.onQuoteRequested() rejects hidden target quotes", async () => {
   );
 });
 
+test("BotImpl.onQuoteRequested() rejects wider-audience quotes", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "followers",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Followers only`, {
+    visibility: "followers",
+  });
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow"),
+    actor,
+  );
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/public-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted publicly.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/6"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Reject);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+});
+
 test("AuthorizedMessage.unauthorizeQuote() checks the target message", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3436,6 +3436,56 @@ test("BotImpl.onQuoteRequested() rejects disallowed quote requests", async () =>
   );
 });
 
+test("BotImpl.onQuoteRequested() rejects hidden target quotes", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  let handled = false;
+  bot.onQuoteRequest = () => {
+    handled = true;
+  };
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Followers only`, {
+    visibility: "followers",
+  });
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/hidden-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/5"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Reject);
+  assert.deepStrictEqual(handled, false);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+});
+
 test("AuthorizedMessage.unauthorizeQuote() checks the target message", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3388,6 +3388,51 @@ test("BotImpl.onQuoteRequested() accepts public quote requests", async () => {
   assert.deepStrictEqual(ctx.sentActivities[1].recipients, "followers");
 });
 
+test("BotImpl.onQuoteRequested() accepts FEP quote IDs", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Quote me`);
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/fep-quote"),
+    attribution: actor.id,
+    quote: target.id,
+    content: "Quoted with FEP-044f.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/fep"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Accept);
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quote.id!,
+  );
+  assert.deepStrictEqual(authorization?.interactingObjectId, quote.id);
+  assert.deepStrictEqual(authorization?.interactionTargetId, target.id);
+});
+
 test("BotImpl.onQuoteRequested() rejects disallowed quote requests", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3475,10 +3475,7 @@ test("BotImpl.onQuoteRequested() rejects hidden target quotes", async () => {
     }),
   );
 
-  assert.deepStrictEqual(ctx.sentActivities.length, 1);
-  const { recipients, activity } = ctx.sentActivities[0];
-  assert.deepStrictEqual(recipients, [actor]);
-  assert.ok(activity instanceof Reject);
+  assert.deepStrictEqual(ctx.sentActivities, []);
   assert.ok(!handled);
   assert.deepStrictEqual(
     await repository.findQuoteAuthorization("bot", quote.id!),
@@ -3535,6 +3532,81 @@ test("BotImpl.onQuoteRequested() rejects wider-audience quotes", async () => {
     await repository.findQuoteAuthorization("bot", quote.id!),
     undefined,
   );
+});
+
+test("BotImpl.onQuoteRequested() revokes widened quote stamps", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "followers",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Followers only`, {
+    visibility: "followers",
+  });
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+    followers: new URL("https://remote.example/users/alice/followers"),
+  });
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow"),
+    actor,
+  );
+  const quoteId = new URL("https://remote.example/notes/widened-quote");
+  const followersQuote = new Note({
+    id: quoteId,
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted to followers.",
+    to: actor.followersId,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/7"),
+      actor,
+      object: target.id,
+      instrument: followersQuote,
+    }),
+  );
+
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quoteId,
+  );
+  assert.ok(authorization != null);
+  ctx.sentActivities = [];
+  const publicQuote = followersQuote.clone({ to: PUBLIC_COLLECTION });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/8"),
+      actor,
+      object: target.id,
+      instrument: publicQuote,
+    }),
+  );
+
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quoteId),
+    undefined,
+  );
+  assert.deepStrictEqual(ctx.sentActivities.length, 3);
+  assert.ok(ctx.sentActivities[0].activity instanceof Delete);
+  assert.deepStrictEqual(
+    ctx.sentActivities[0].activity.objectId,
+    authorization.id,
+  );
+  assert.deepStrictEqual(ctx.sentActivities[1].recipients, "followers");
+  assert.ok(ctx.sentActivities[2].activity instanceof Reject);
 });
 
 test("BotImpl.onQuoteRequested() rejects unknown-audience quotes", async () => {

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -2223,6 +2223,68 @@ test("BotImpl.onCreated()", async (t) => {
     ctx.forwardedRecipients = [];
   });
 
+  await t.test("on authorized FEP quote update", async () => {
+    const quoteId = new URL(
+      "https://example.com/ap/note/9cfd7129-4cf0-4505-90d8-3cac2dc42439",
+    );
+    const targetId = new URL(
+      "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
+    );
+    const authorizationId = "01950000-0000-7000-8000-000000000204" as Uuid;
+    const authorizationUrl = new URL(
+      "https://example.com/ap/actor/bot/quote-authorization/" +
+        authorizationId,
+    );
+    await repository.addQuoteAuthorization(
+      "bot",
+      authorizationId,
+      new QuoteAuthorization({
+        id: authorizationUrl,
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+    );
+    const update = new Update({
+      id: new URL(
+        "https://example.com/ap/update/9cfd7129-4cf0-4505-90d8-3cac2dc42439",
+      ),
+      actor: new URL("https://example.com/ap/actor/john"),
+      to: PUBLIC_COLLECTION,
+      cc: new URL("https://example.com/ap/actor/john/followers"),
+      object: new Note({
+        id: quoteId,
+        attribution: new Person({
+          id: new URL("https://example.com/ap/actor/john"),
+          preferredUsername: "john",
+        }),
+        to: PUBLIC_COLLECTION,
+        cc: new URL("https://example.com/ap/actor/john/followers"),
+        content: "It's an approved FEP quote update!",
+        quote: targetId,
+        quoteAuthorization: authorizationUrl,
+      }),
+    });
+    let quoted: [Session<void>, Message<MessageClass, void>][] = [];
+    bot.onQuote = (session, msg) => void (quoted.push([session, msg]));
+
+    await bot.onUpdated(ctx, update);
+
+    assert.deepStrictEqual(quoted.length, 1);
+    const [, msg] = quoted[0];
+    assert.ok(msg.quoteTarget != null);
+    assert.deepStrictEqual(msg.quoteTarget.id, targetId);
+    assert.deepStrictEqual(replied, []);
+    assert.deepStrictEqual(mentioned, []);
+    assert.deepStrictEqual(messaged, quoted);
+    assert.deepStrictEqual(ctx.sentActivities, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+
+    quoted = [];
+    messaged = [];
+    ctx.forwardedRecipients = [];
+  });
+
   await t.test("on authorized FEP quote with mismatched fallback link", async () => {
     const quoteId = new URL(
       "https://example.com/ap/note/9cfd7129-4cf0-4505-90d8-3cac2dc42437",
@@ -2384,11 +2446,22 @@ test("BotImpl.onCreated()", async (t) => {
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
     assert.deepStrictEqual(messaged, []);
-    assert.deepStrictEqual(ctx.sentActivities, []);
+    assert.deepStrictEqual(ctx.sentActivities.length, 2);
+    const [actorDelete, followersDelete] = ctx.sentActivities;
+    assert.deepStrictEqual(
+      actorDelete.recipients,
+      [actor],
+    );
+    assert.ok(actorDelete.activity instanceof Delete);
+    assert.deepStrictEqual(actorDelete.activity.objectId, authorizationUrl);
+    assert.deepStrictEqual(followersDelete.recipients, "followers");
+    assert.ok(followersDelete.activity instanceof Delete);
+    assert.deepStrictEqual(followersDelete.activity.objectId, authorizationUrl);
     assert.deepStrictEqual(ctx.forwardedRecipients, []);
 
     quoted = [];
     messaged = [];
+    ctx.sentActivities = [];
     ctx.forwardedRecipients = [];
   });
 

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3535,6 +3535,99 @@ test("BotImpl.onQuoteRequested() rejects wider-audience quotes", async () => {
   );
 });
 
+test("BotImpl.onQuoteRequested() rejects unrelated quote instruments", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Quote me`);
+  const otherTarget = await session.publish(text`Not this`);
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/unrelated-quote"),
+    attribution: actor.id,
+    quoteUrl: otherTarget.id,
+    content: "Quoted.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/unrelated"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities, []);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+});
+
+test("BotImpl.onQuoteRequested() rejects non-subset quote audiences", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "followers",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Followers only`, {
+    visibility: "followers",
+  });
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+    followers: new URL("https://remote.example/users/alice/followers"),
+  });
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow"),
+    actor,
+  );
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/own-followers-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted to my followers.",
+    to: actor.followersId,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/own-followers"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Reject);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+});
+
 test("BotImpl.onQuoteRequested() revokes widened quote stamps", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({
@@ -3564,8 +3657,9 @@ test("BotImpl.onQuoteRequested() revokes widened quote stamps", async () => {
     id: quoteId,
     attribution: actor.id,
     quoteUrl: target.id,
-    content: "Quoted to followers.",
-    to: actor.followersId,
+    content: "Quoted directly.",
+    to: actor.id,
+    tags: [new Mention({ href: actor.id })],
   });
 
   await bot.onQuoteRequested(

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3479,7 +3479,7 @@ test("BotImpl.onQuoteRequested() rejects hidden target quotes", async () => {
   const { recipients, activity } = ctx.sentActivities[0];
   assert.deepStrictEqual(recipients, [actor]);
   assert.ok(activity instanceof Reject);
-  assert.deepStrictEqual(handled, false);
+  assert.ok(!handled);
   assert.deepStrictEqual(
     await repository.findQuoteAuthorization("bot", quote.id!),
     undefined,
@@ -3521,6 +3521,57 @@ test("BotImpl.onQuoteRequested() rejects wider-audience quotes", async () => {
     ctx,
     new QuoteRequest({
       id: new URL("https://remote.example/quote-requests/6"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Reject);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+});
+
+test("BotImpl.onQuoteRequested() rejects unknown-audience quotes", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "followers",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Followers only`, {
+    visibility: "followers",
+  });
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow"),
+    actor,
+  );
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/custom-audience-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted to a custom audience.",
+    to: new URL("https://remote.example/custom-audience"),
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/7"),
       actor,
       object: target.id,
       instrument: quote,

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -2068,6 +2068,55 @@ test("BotImpl.onCreated()", async (t) => {
     ctx.forwardedRecipients = [];
   });
 
+  await t.test("on FEP quote", async () => {
+    const create = new Create({
+      id: new URL(
+        "https://example.com/ap/create/9cfd7129-4cf0-4505-90d8-3cac2dc42435",
+      ),
+      actor: new URL("https://example.com/ap/actor/john"),
+      to: PUBLIC_COLLECTION,
+      cc: new URL("https://example.com/ap/actor/john/followers"),
+      object: new Note({
+        id: new URL(
+          "https://example.com/ap/note/9cfd7129-4cf0-4505-90d8-3cac2dc42435",
+        ),
+        attribution: new Person({
+          id: new URL("https://example.com/ap/actor/john"),
+          preferredUsername: "john",
+        }),
+        to: PUBLIC_COLLECTION,
+        cc: new URL("https://example.com/ap/actor/john/followers"),
+        content: "It's a FEP quote!",
+        quote: new URL(
+          "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
+        ),
+      }),
+    });
+    let quoted: [Session<void>, Message<MessageClass, void>][] = [];
+    bot.onQuote = (session, msg) => void (quoted.push([session, msg]));
+
+    await bot.onCreated(ctx, create);
+
+    assert.deepStrictEqual(quoted.length, 1);
+    const [, msg] = quoted[0];
+    assert.ok(msg.quoteTarget != null);
+    assert.deepStrictEqual(
+      msg.quoteTarget.id,
+      new URL(
+        "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
+      ),
+    );
+    assert.deepStrictEqual(replied, []);
+    assert.deepStrictEqual(mentioned, []);
+    assert.deepStrictEqual(messaged, quoted);
+    assert.deepStrictEqual(ctx.sentActivities, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+
+    quoted = [];
+    messaged = [];
+    ctx.forwardedRecipients = [];
+  });
+
   await t.test("on message", async () => {
     const create = new Create({
       id: new URL(
@@ -3395,6 +3444,10 @@ test("BotImpl.onQuoteRequested() accepts FEP quote IDs", async () => {
     repository,
     username: "bot",
   });
+  let quoteMessage: Message<MessageClass, void> | undefined;
+  bot.onQuoteRequest = (_session, request) => {
+    quoteMessage = request.quote;
+  };
   const ctx = createMockInboxContext(bot, "https://example.com", "bot");
   const session = new SessionImpl(bot, ctx);
   const target = await session.publish(text`Quote me`);
@@ -3431,6 +3484,75 @@ test("BotImpl.onQuoteRequested() accepts FEP quote IDs", async () => {
   );
   assert.deepStrictEqual(authorization?.interactingObjectId, quote.id);
   assert.deepStrictEqual(authorization?.interactionTargetId, target.id);
+  assert.deepStrictEqual(quoteMessage?.quoteTarget?.id, target.id);
+});
+
+test("BotImpl.onQuoteRequested() replays manual quote approvals", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "manual",
+  });
+  let handled = 0;
+  bot.onQuoteRequest = async (_session, request) => {
+    handled++;
+    await request.accept();
+  };
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Review quotes`);
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/manual-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted after review.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/manual"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(handled, 1);
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  assert.ok(ctx.sentActivities[0].activity instanceof Accept);
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quote.id!,
+  );
+  assert.ok(authorization?.id != null);
+  ctx.sentActivities = [];
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/manual-again"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(handled, 1);
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  assert.ok(ctx.sentActivities[0].activity instanceof Accept);
+  assert.deepStrictEqual(
+    ctx.sentActivities[0].activity.resultId?.href,
+    authorization.id.href,
+  );
 });
 
 test("BotImpl.onQuoteRequested() rejects disallowed quote requests", async () => {

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -2068,7 +2068,7 @@ test("BotImpl.onCreated()", async (t) => {
     ctx.forwardedRecipients = [];
   });
 
-  await t.test("on FEP quote", async () => {
+  await t.test("on unauthorized FEP quote", async () => {
     const create = new Create({
       id: new URL(
         "https://example.com/ap/create/9cfd7129-4cf0-4505-90d8-3cac2dc42435",
@@ -2097,14 +2097,71 @@ test("BotImpl.onCreated()", async (t) => {
 
     await bot.onCreated(ctx, create);
 
+    assert.deepStrictEqual(quoted, []);
+    assert.deepStrictEqual(replied, []);
+    assert.deepStrictEqual(mentioned, []);
+    assert.deepStrictEqual(messaged.length, 1);
+    assert.deepStrictEqual(ctx.sentActivities, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, []);
+
+    quoted = [];
+    messaged = [];
+    ctx.forwardedRecipients = [];
+  });
+
+  await t.test("on authorized FEP quote", async () => {
+    const quoteId = new URL(
+      "https://example.com/ap/note/9cfd7129-4cf0-4505-90d8-3cac2dc42435",
+    );
+    const targetId = new URL(
+      "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
+    );
+    const authorizationId = "01950000-0000-7000-8000-000000000201" as Uuid;
+    const authorizationUrl = new URL(
+      "https://example.com/ap/actor/bot/quote-authorization/" +
+        authorizationId,
+    );
+    await repository.addQuoteAuthorization(
+      "bot",
+      authorizationId,
+      new QuoteAuthorization({
+        id: authorizationUrl,
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+    );
+    const create = new Create({
+      id: new URL(
+        "https://example.com/ap/create/9cfd7129-4cf0-4505-90d8-3cac2dc42435",
+      ),
+      actor: new URL("https://example.com/ap/actor/john"),
+      to: PUBLIC_COLLECTION,
+      cc: new URL("https://example.com/ap/actor/john/followers"),
+      object: new Note({
+        id: quoteId,
+        attribution: new Person({
+          id: new URL("https://example.com/ap/actor/john"),
+          preferredUsername: "john",
+        }),
+        to: PUBLIC_COLLECTION,
+        cc: new URL("https://example.com/ap/actor/john/followers"),
+        content: "It's a FEP quote!",
+        quote: targetId,
+        quoteAuthorization: authorizationUrl,
+      }),
+    });
+    let quoted: [Session<void>, Message<MessageClass, void>][] = [];
+    bot.onQuote = (session, msg) => void (quoted.push([session, msg]));
+
+    await bot.onCreated(ctx, create);
+
     assert.deepStrictEqual(quoted.length, 1);
     const [, msg] = quoted[0];
     assert.ok(msg.quoteTarget != null);
     assert.deepStrictEqual(
       msg.quoteTarget.id,
-      new URL(
-        "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
-      ),
+      targetId,
     );
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -2223,6 +2223,99 @@ test("BotImpl.onCreated()", async (t) => {
     ctx.forwardedRecipients = [];
   });
 
+  await t.test("on authorized FEP quote with mismatched fallback link", async () => {
+    const quoteId = new URL(
+      "https://example.com/ap/note/9cfd7129-4cf0-4505-90d8-3cac2dc42437",
+    );
+    const fallbackTargetId = new URL(
+      "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
+    );
+    const fepTargetId = new URL(
+      "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168df",
+    );
+    await repository.addMessage(
+      "bot",
+      "a6358f1b-c978-49d3-8065-37a1df6168df",
+      new Create({
+        id: new URL(
+          "https://example.com/ap/create/a6358f1b-c978-49d3-8065-37a1df6168df",
+        ),
+        actor: new URL("https://example.com/ap/actor/bot"),
+        to: PUBLIC_COLLECTION,
+        cc: new URL("https://example.com/ap/actor/bot/followers"),
+        object: new Note({
+          id: fepTargetId,
+          attribution: new URL("https://example.com/ap/actor/bot"),
+          to: PUBLIC_COLLECTION,
+          cc: new URL("https://example.com/ap/actor/bot/followers"),
+          content: "Another local post",
+        }),
+      }),
+    );
+    const authorizationId = "01950000-0000-7000-8000-000000000202" as Uuid;
+    const authorizationUrl = new URL(
+      "https://example.com/ap/actor/bot/quote-authorization/" +
+        authorizationId,
+    );
+    await repository.addQuoteAuthorization(
+      "bot",
+      authorizationId,
+      new QuoteAuthorization({
+        id: authorizationUrl,
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        interactingObject: quoteId,
+        interactionTarget: fepTargetId,
+      }),
+    );
+    const create = new Create({
+      id: new URL(
+        "https://example.com/ap/create/9cfd7129-4cf0-4505-90d8-3cac2dc42437",
+      ),
+      actor: new URL("https://example.com/ap/actor/john"),
+      to: PUBLIC_COLLECTION,
+      cc: new URL("https://example.com/ap/actor/john/followers"),
+      object: new Note({
+        id: quoteId,
+        attribution: new Person({
+          id: new URL("https://example.com/ap/actor/john"),
+          preferredUsername: "john",
+        }),
+        to: PUBLIC_COLLECTION,
+        cc: new URL("https://example.com/ap/actor/john/followers"),
+        content: "It's a FEP quote with a mismatched fallback link!",
+        quote: fepTargetId,
+        quoteAuthorization: authorizationUrl,
+        tags: [
+          new Link({
+            href: fallbackTargetId,
+            mediaType: "application/activity+json",
+          }),
+        ],
+      }),
+    });
+    let quoted: [Session<void>, Message<MessageClass, void>][] = [];
+    bot.onQuote = (session, msg) => void (quoted.push([session, msg]));
+
+    await bot.onCreated(ctx, create);
+
+    assert.deepStrictEqual(quoted.length, 1);
+    const [, msg] = quoted[0];
+    assert.ok(msg.quoteTarget != null);
+    assert.deepStrictEqual(
+      msg.quoteTarget.id,
+      fepTargetId,
+    );
+    assert.deepStrictEqual(replied, []);
+    assert.deepStrictEqual(mentioned, []);
+    assert.deepStrictEqual(messaged, quoted);
+    assert.deepStrictEqual(ctx.sentActivities, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+
+    quoted = [];
+    messaged = [];
+    ctx.forwardedRecipients = [];
+  });
+
   await t.test("on message", async () => {
     const create = new Create({
       id: new URL(

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -2316,6 +2316,82 @@ test("BotImpl.onCreated()", async (t) => {
     ctx.forwardedRecipients = [];
   });
 
+  await t.test("on authorized FEP quote with widened audience", async () => {
+    const quoteId = new URL(
+      "https://example.com/ap/note/9cfd7129-4cf0-4505-90d8-3cac2dc42438",
+    );
+    const targetId = new URL(
+      "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168e0",
+    );
+    await repository.addMessage(
+      "bot",
+      "a6358f1b-c978-49d3-8065-37a1df6168e0",
+      new Create({
+        id: new URL(
+          "https://example.com/ap/create/a6358f1b-c978-49d3-8065-37a1df6168e0",
+        ),
+        actor: new URL("https://example.com/ap/actor/bot"),
+        to: new URL("https://example.com/ap/actor/bot/followers"),
+        object: new Note({
+          id: targetId,
+          attribution: new URL("https://example.com/ap/actor/bot"),
+          to: new URL("https://example.com/ap/actor/bot/followers"),
+          content: "Followers only",
+        }),
+      }),
+    );
+    const authorizationId = "01950000-0000-7000-8000-000000000203" as Uuid;
+    const authorizationUrl = new URL(
+      "https://example.com/ap/actor/bot/quote-authorization/" +
+        authorizationId,
+    );
+    await repository.addQuoteAuthorization(
+      "bot",
+      authorizationId,
+      new QuoteAuthorization({
+        id: authorizationUrl,
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+    );
+    const actor = new Person({
+      id: new URL("https://example.com/ap/actor/john"),
+      preferredUsername: "john",
+      followers: new URL("https://example.com/ap/actor/john/followers"),
+    });
+    const create = new Create({
+      id: new URL(
+        "https://example.com/ap/create/9cfd7129-4cf0-4505-90d8-3cac2dc42438",
+      ),
+      actor,
+      to: PUBLIC_COLLECTION,
+      object: new Note({
+        id: quoteId,
+        attribution: actor,
+        to: PUBLIC_COLLECTION,
+        content: "It's a public FEP quote of a followers-only post!",
+        quote: targetId,
+        quoteAuthorization: authorizationUrl,
+      }),
+    });
+    let quoted: [Session<void>, Message<MessageClass, void>][] = [];
+    bot.onQuote = (session, msg) => void (quoted.push([session, msg]));
+
+    await bot.onCreated(ctx, create);
+
+    assert.deepStrictEqual(quoted, []);
+    assert.deepStrictEqual(replied, []);
+    assert.deepStrictEqual(mentioned, []);
+    assert.deepStrictEqual(messaged.length, 1);
+    assert.deepStrictEqual(ctx.sentActivities, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, []);
+
+    quoted = [];
+    messaged = [];
+    ctx.forwardedRecipients = [];
+  });
+
   await t.test("on message", async () => {
     const create = new Create({
       id: new URL(

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -3628,6 +3628,59 @@ test("BotImpl.onQuoteRequested() rejects non-subset quote audiences", async () =
   );
 });
 
+test("BotImpl.onQuoteRequested() accepts quotes to the target author", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "followers",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Followers only`, {
+    visibility: "followers",
+  });
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow"),
+    actor,
+  );
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/author-only-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted to the original author.",
+    to: session.actorId,
+    tags: [new Mention({ href: session.actorId })],
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/author-only"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Accept);
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quote.id!,
+  );
+  assert.deepStrictEqual(authorization?.interactionTargetId, target.id);
+});
+
 test("BotImpl.onQuoteRequested() revokes widened quote stamps", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -36,6 +36,7 @@ import {
   PropertyValue,
   PUBLIC_COLLECTION,
   Question,
+  QuoteRequest,
   type Recipient,
   Reject,
   Service,
@@ -47,7 +48,12 @@ import { describe, test } from "node:test";
 import { BotImpl } from "./bot-impl.ts";
 import type { CustomEmoji } from "./emoji.ts";
 import type { FollowRequest } from "./follow.ts";
-import type { Message, MessageClass, SharedMessage } from "./message.ts";
+import type {
+  AuthorizedMessage,
+  Message,
+  MessageClass,
+  SharedMessage,
+} from "./message.ts";
 import type { Vote } from "./poll.ts";
 import type { Like, Reaction } from "./reaction.ts";
 import { MemoryRepository } from "./repository.ts";
@@ -3288,5 +3294,311 @@ test("BotImpl.onLiked() with legacy message URIs", async () => {
   assert.deepStrictEqual(
     likes[0].message.id,
     new URL(`https://example.com/ap/actor/bot/note/${messageId}`),
+  );
+});
+
+test("BotImpl.onQuoteRequested() accepts public quote requests", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  let targetMessage: AuthorizedMessage<MessageClass, void> | undefined;
+  let quoteMessage: Message<MessageClass, void> | undefined;
+  bot.onQuoteRequest = (_session, request) => {
+    targetMessage = request.target;
+    quoteMessage = request.quote;
+  };
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Quote me`);
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted.",
+    to: PUBLIC_COLLECTION,
+  });
+  const request = new QuoteRequest({
+    id: new URL("https://remote.example/quote-requests/1"),
+    actor,
+    object: target.id,
+    instrument: quote,
+  });
+
+  await bot.onQuoteRequested(ctx, request);
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Accept);
+  assert.deepStrictEqual(
+    activity.resultId?.href.startsWith(
+      "https://example.com/ap/actor/bot/quote-authorization/",
+    ),
+    true,
+  );
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quote.id!,
+  );
+  assert.deepStrictEqual(authorization?.interactingObjectId, quote.id);
+  assert.deepStrictEqual(authorization?.interactionTargetId, target.id);
+  assert.ok(authorization?.id != null);
+
+  ctx.sentActivities = [];
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/1-again"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  assert.ok(ctx.sentActivities[0].activity instanceof Accept);
+  assert.deepStrictEqual(
+    ctx.sentActivities[0].activity.resultId?.href,
+    authorization.id.href,
+  );
+
+  assert.ok(targetMessage != null);
+  assert.ok(quoteMessage != null);
+  ctx.sentActivities = [];
+  await targetMessage.unauthorizeQuote(quoteMessage);
+
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+  assert.deepStrictEqual(ctx.sentActivities.length, 2);
+  const { recipients: deleteRecipients, activity: deleteActivity } =
+    ctx.sentActivities[0];
+  assert.deepStrictEqual(deleteRecipients, [actor]);
+  assert.ok(deleteActivity instanceof Delete);
+  assert.deepStrictEqual(deleteActivity.objectId, authorization.id);
+  assert.deepStrictEqual(ctx.sentActivities[1].recipients, "followers");
+});
+
+test("BotImpl.onQuoteRequested() rejects disallowed quote requests", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "nobody",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Do not quote`, {
+    quotePolicy: "nobody",
+  });
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow"),
+    actor,
+  );
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/rejected-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/2"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  assert.ok(ctx.sentActivities[0].activity instanceof Reject);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+});
+
+test("AuthorizedMessage.unauthorizeQuote() checks the target message", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  let quoteMessage: Message<MessageClass, void> | undefined;
+  bot.onQuoteRequest = (_session, request) => {
+    quoteMessage = request.quote;
+  };
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const firstTarget = await session.publish(text`Quote this`);
+  const secondTarget = await session.publish(text`Not this`);
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/quote"),
+    attribution: actor.id,
+    quoteUrl: firstTarget.id,
+    content: "Quoted.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/3"),
+      actor,
+      object: firstTarget.id,
+      instrument: quote,
+    }),
+  );
+
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quote.id!,
+  );
+  assert.ok(quoteMessage != null);
+  assert.ok(authorization != null);
+  const authorizedQuote = quoteMessage;
+  ctx.sentActivities = [];
+  await assert.rejects(
+    () => secondTarget.unauthorizeQuote(authorizedQuote),
+    /does not belong to this message/,
+  );
+
+  assert.deepStrictEqual(
+    (await repository.findQuoteAuthorization("bot", quote.id!))?.id?.href,
+    authorization.id?.href,
+  );
+  assert.deepStrictEqual(ctx.sentActivities, []);
+});
+
+test("AuthorizedMessage.unauthorizeQuote() revokes when quote lookup fails", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const target = await new SessionImpl(bot, ctx).publish(text`Quote this`);
+  ctx.sentActivities = [];
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/deleted-quote"),
+    attribution: actor.id,
+    quoteUrl: target.id,
+    content: "Quoted.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/4"),
+      actor,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  const authorization = await repository.findQuoteAuthorization(
+    "bot",
+    quote.id!,
+  );
+  assert.ok(authorization != null);
+  Object.defineProperty(ctx, "lookupObject", {
+    value: () => Promise.reject(new TypeError("Remote quote is gone.")),
+    configurable: true,
+  });
+  ctx.sentActivities = [];
+
+  await target.unauthorizeQuote(quote.id!);
+
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, "followers");
+  assert.ok(activity instanceof Delete);
+  assert.deepStrictEqual(activity.objectId, authorization.id);
+});
+
+test("BotImpl.onQuoteRequested() rejects another actor's quote", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "followers",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = await session.publish(text`Followers may quote me`);
+  ctx.sentActivities = [];
+  const requester = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quoteAuthor = new Person({
+    id: new URL("https://remote.example/users/mallory"),
+    preferredUsername: "mallory",
+  });
+  await repository.addFollower(
+    "bot",
+    new URL("https://remote.example/activities/follow"),
+    requester,
+  );
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/borrowed-quote"),
+    attribution: quoteAuthor.id,
+    quoteUrl: target.id,
+    content: "Quoted by somebody else.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/3"),
+      actor: requester,
+      object: target.id,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [requester]);
+  assert.ok(activity instanceof Reject);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
   );
 });

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -4120,6 +4120,72 @@ test("BotImpl.onQuoteRequested() rejects unknown-audience quotes", async () => {
   );
 });
 
+test("BotImpl.onQuoteRequested() checks direct quote recipients for unknown targets", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+    quotePolicy: "public",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const actor = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const unrelatedActor = new Person({
+    id: new URL("https://remote.example/users/bob"),
+    preferredUsername: "bob",
+  });
+  const targetId = new URL(
+    "https://example.com/ap/note/01950000-0000-7000-8000-000000000101",
+  );
+  await repository.addMessage(
+    "bot",
+    "01950000-0000-7000-8000-000000000101" as Uuid,
+    new Create({
+      id: new URL(
+        "https://example.com/ap/create/01950000-0000-7000-8000-000000000101",
+      ),
+      actor: session.actorId,
+      object: new Note({
+        id: targetId,
+        attribution: session.actorId,
+        content: "A target with an unrecognized audience.",
+        to: actor.id,
+      }),
+    }),
+  );
+  const quote = new Note({
+    id: new URL("https://remote.example/notes/direct-quote-outside-target"),
+    attribution: actor.id,
+    quoteUrl: targetId,
+    content: "Quoted directly to someone else.",
+    to: unrelatedActor.id,
+    tags: [new Mention({ href: unrelatedActor.id })],
+  });
+
+  await bot.onQuoteRequested(
+    ctx,
+    new QuoteRequest({
+      id: new URL("https://remote.example/quote-requests/direct-outside"),
+      actor,
+      object: targetId,
+      instrument: quote,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  const { recipients, activity } = ctx.sentActivities[0];
+  assert.deepStrictEqual(recipients, [actor]);
+  assert.ok(activity instanceof Reject);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", quote.id!),
+    undefined,
+  );
+});
+
 test("AuthorizedMessage.unauthorizeQuote() checks the target message", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -970,7 +970,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
 
   async #hasValidQuoteAuthorization(
     ctx: InboxContext<TContextData>,
-    object: Object,
+    object: MessageClass,
     targetId: URL,
   ): Promise<boolean> {
     if (
@@ -1033,7 +1033,17 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
         targetVisibility,
       )
     ) {
-      await this.repository.removeQuoteAuthorization(parsed.values.id as Uuid);
+      const session = this.getSession(ctx);
+      const target = await createMessage(
+        targetObject,
+        session,
+        {},
+        undefined,
+        undefined,
+        true,
+      );
+      const quote = await createMessage(object, session, {});
+      await target.unauthorizeQuote(quote);
       return false;
     }
     return true;
@@ -1042,6 +1052,20 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
   async onCreated(
     ctx: InboxContext<TContextData>,
     create: Create,
+  ): Promise<void> {
+    await this.#onCreatedOrUpdated(ctx, create);
+  }
+
+  async onUpdated(
+    ctx: InboxContext<TContextData>,
+    update: Update,
+  ): Promise<void> {
+    await this.#onCreatedOrUpdated(ctx, update);
+  }
+
+  async #onCreatedOrUpdated(
+    ctx: InboxContext<TContextData>,
+    create: Create | Update,
   ): Promise<void> {
     const object = await create.getObject(ctx);
     if (

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -688,7 +688,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     ctx: InboxContext<TContextData>,
     request: RawQuoteRequest,
   ): Promise<void> {
-    if (request.actorId == null) return;
+    if (request.id == null || request.actorId == null) return;
     const parsedObj = parseLocalUri(
       ctx,
       request.objectId,
@@ -712,7 +712,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       documentLoader,
       suppressError: true,
     });
-    if (!isMessageObject(instrument)) return;
+    if (!isMessageObject(instrument) || instrument.id == null) return;
     const actor = await request.getActor({
       contextLoader: ctx.contextLoader,
       documentLoader,
@@ -721,17 +721,6 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     if (!isActor(actor) || actor.id == null) return;
     const session = this.getSession(ctx);
     if (!await this.#canActorSeeObject(ctx, actor.id, targetObject)) {
-      await session.context.sendActivity(
-        this,
-        actor,
-        new Reject({
-          id: new URL(`/#reject/${request.id?.href}`, session.actorId),
-          actor: session.actorId,
-          to: actor.id,
-          object: request,
-        }),
-        { excludeBaseUris: [new URL(session.context.origin)] },
-      );
       return;
     }
     if (
@@ -765,7 +754,30 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     const quote = await createMessage(quoteObject, session, {
       [actor.id.href]: actor,
     });
+    const existingAuthorization = await this.repository.findQuoteAuthorization(
+      quote.id,
+    );
+    if (
+      existingAuthorization != null &&
+      existingAuthorization.interactionTargetId?.href !== target.id.href
+    ) {
+      await session.context.sendActivity(
+        this,
+        actor,
+        new Reject({
+          id: new URL(`/#reject/${request.id.href}`, session.actorId),
+          actor: session.actorId,
+          to: actor.id,
+          object: request,
+        }),
+        { excludeBaseUris: [new URL(session.context.origin)] },
+      );
+      return;
+    }
     if (this.#isQuoteAudienceWider(quote.visibility, target.visibility)) {
+      if (existingAuthorization != null) {
+        await target.unauthorizeQuote(quote);
+      }
       await session.context.sendActivity(
         this,
         actor,

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -94,7 +94,12 @@ import {
   isQuoteLink,
   messageClasses,
 } from "./message-impl.ts";
-import type { Message, MessageClass, SharedMessage } from "./message.ts";
+import type {
+  Message,
+  MessageClass,
+  MessageVisibility,
+  SharedMessage,
+} from "./message.ts";
 import type { Vote } from "./poll.ts";
 import { QuoteRequestImpl } from "./quote-impl.ts";
 import { normalizeQuotePolicy, type QuotePolicyOption } from "./quote.ts";
@@ -760,6 +765,20 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     const quote = await createMessage(quoteObject, session, {
       [actor.id.href]: actor,
     });
+    if (this.#isQuoteAudienceWider(quote.visibility, target.visibility)) {
+      await session.context.sendActivity(
+        this,
+        actor,
+        new Reject({
+          id: new URL(`/#reject/${request.id?.href}`, session.actorId),
+          actor: session.actorId,
+          to: actor.id,
+          object: request,
+        }),
+        { excludeBaseUris: [new URL(session.context.origin)] },
+      );
+      return;
+    }
     const quoteRequest = new QuoteRequestImpl(
       session,
       request,
@@ -804,6 +823,22 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     if (recipients.includes(actorId.href)) return true;
     return recipients.includes(ctx.getFollowersUri(this.identifier).href) &&
       await this.repository.hasFollower(actorId);
+  }
+
+  #isQuoteAudienceWider(
+    quoteVisibility: MessageVisibility,
+    targetVisibility: MessageVisibility,
+  ): boolean {
+    const ranks: Record<MessageVisibility, number | undefined> = {
+      public: 4,
+      unlisted: 3,
+      followers: 2,
+      direct: 1,
+      unknown: undefined,
+    };
+    const quoteRank = ranks[quoteVisibility];
+    const targetRank = ranks[targetVisibility];
+    return quoteRank != null && targetRank != null && quoteRank > targetRank;
   }
 
   async #matchesQuoteAcceptance(

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -869,6 +869,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     const targetRecipients = new Set(
       [...targetObject.toIds, ...targetObject.ccIds].map((u) => u.href),
     );
+    targetRecipients.add(ctx.getActorUri(this.identifier).href);
     if (targetRecipients.has(PUBLIC_COLLECTION.href)) return true;
     const followerCollection = ctx.getFollowersUri(this.identifier).href;
     const actorIsFollower = targetRecipients.has(followerCollection) &&

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -1139,7 +1139,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       }
     }
     const fepQuoteUrl = object.quoteId;
-    const requiresQuoteAuthorization = quoteUrl == null && fepQuoteUrl != null;
+    const requiresQuoteAuthorization = fepQuoteUrl != null;
     if (quoteUrl == null) quoteUrl = fepQuoteUrl ?? object.quoteUrl;
     const quoteTarget = parseLocalUri(
       ctx,

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -706,7 +706,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     );
     if (!(stored instanceof Create)) return;
     const targetObject = await stored.getObject(ctx);
-    if (!isMessageObject(targetObject)) return;
+    if (!isMessageObject(targetObject) || targetObject.id == null) return;
     const documentLoader = await ctx.getDocumentLoader(this);
     const instrument = await request.getInstrument({
       contextLoader: ctx.contextLoader,
@@ -714,6 +714,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       suppressError: true,
     });
     if (!isMessageObject(instrument) || instrument.id == null) return;
+    if (instrument.quoteUrl?.href !== targetObject.id.href) return;
     const actor = await request.getActor({
       contextLoader: ctx.contextLoader,
       documentLoader,
@@ -769,7 +770,16 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       await rejectRequest();
       return;
     }
-    if (this.#isQuoteAudienceWider(quote.visibility, target.visibility)) {
+    if (
+      await this.#isQuoteAudienceWider(
+        ctx,
+        actor.id,
+        quoteObject,
+        targetObject,
+        quote.visibility,
+        target.visibility,
+      )
+    ) {
       if (existingAuthorization != null) {
         await target.unauthorizeQuote(quote);
       }
@@ -822,10 +832,14 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       await this.repository.hasFollower(actorId);
   }
 
-  #isQuoteAudienceWider(
+  async #isQuoteAudienceWider(
+    ctx: InboxContext<TContextData>,
+    actorId: URL,
+    quoteObject: Object,
+    targetObject: Object,
     quoteVisibility: MessageVisibility,
     targetVisibility: MessageVisibility,
-  ): boolean {
+  ): Promise<boolean> {
     if (targetVisibility === "unknown") return quoteVisibility !== "direct";
     if (quoteVisibility === "unknown") {
       return targetVisibility !== "public" && targetVisibility !== "unlisted";
@@ -837,7 +851,34 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       direct: 1,
       unknown: 0,
     };
-    return ranks[quoteVisibility] > ranks[targetVisibility];
+    if (ranks[quoteVisibility] > ranks[targetVisibility]) return true;
+    return !await this.#isQuoteAudienceSubset(
+      ctx,
+      actorId,
+      quoteObject,
+      targetObject,
+    );
+  }
+
+  async #isQuoteAudienceSubset(
+    ctx: InboxContext<TContextData>,
+    actorId: URL,
+    quoteObject: Object,
+    targetObject: Object,
+  ): Promise<boolean> {
+    const targetRecipients = new Set(
+      [...targetObject.toIds, ...targetObject.ccIds].map((u) => u.href),
+    );
+    if (targetRecipients.has(PUBLIC_COLLECTION.href)) return true;
+    const followerCollection = ctx.getFollowersUri(this.identifier).href;
+    const actorIsFollower = targetRecipients.has(followerCollection) &&
+      await this.repository.hasFollower(actorId);
+    for (const recipient of [...quoteObject.toIds, ...quoteObject.ccIds]) {
+      if (targetRecipients.has(recipient.href)) continue;
+      if (actorIsFollower && recipient.href === actorId.href) continue;
+      return false;
+    }
+    return true;
   }
 
   async #matchesQuoteAcceptance(

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -715,6 +715,20 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     });
     if (!isActor(actor) || actor.id == null) return;
     const session = this.getSession(ctx);
+    if (!await this.#canActorSeeObject(ctx, actor.id, targetObject)) {
+      await session.context.sendActivity(
+        this,
+        actor,
+        new Reject({
+          id: new URL(`/#reject/${request.id?.href}`, session.actorId),
+          actor: session.actorId,
+          to: actor.id,
+          object: request,
+        }),
+        { excludeBaseUris: [new URL(session.context.origin)] },
+      );
+      return;
+    }
     if (
       instrument.attributionId != null &&
       instrument.attributionId.href !== actor.id.href
@@ -777,6 +791,19 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       await quoteRequest.reject();
     }
     await this.onQuoteRequest?.(session, quoteRequest);
+  }
+
+  async #canActorSeeObject(
+    ctx: InboxContext<TContextData>,
+    actorId: URL,
+    object: Object,
+  ): Promise<boolean> {
+    if (actorId.href === ctx.getActorUri(this.identifier).href) return true;
+    const recipients = [...object.toIds, ...object.ccIds].map((u) => u.href);
+    if (recipients.includes(PUBLIC_COLLECTION.href)) return true;
+    if (recipients.includes(actorId.href)) return true;
+    return recipients.includes(ctx.getFollowersUri(this.identifier).href) &&
+      await this.repository.hasFollower(actorId);
   }
 
   async #matchesQuoteAcceptance(

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -1222,15 +1222,20 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       quoteUrl,
       this.legacyObjectUrisIdentifier,
     );
-    if (
-      this.onQuote != null &&
-      quoteTarget?.type === "object" &&
+    const isLocalQuoteTarget = quoteTarget?.type === "object" &&
       // @ts-ignore: quoteTarget.class satisfies (typeof messageClasses)[number]
       messageClasses.includes(quoteTarget.class) &&
-      quoteTarget.values.identifier === this.identifier &&
-      (!requiresQuoteAuthorization ||
-        (fepQuoteUrl != null &&
-          await this.#hasValidQuoteAuthorization(ctx, object, fepQuoteUrl)))
+      quoteTarget.values.identifier === this.identifier;
+    const hasValidQuoteAuthorization = !requiresQuoteAuthorization ||
+      (fepQuoteUrl != null && isLocalQuoteTarget &&
+        await this.#hasValidQuoteAuthorization(ctx, object, fepQuoteUrl));
+    if (requiresQuoteAuthorization && isLocalQuoteTarget) {
+      if (!hasValidQuoteAuthorization) return;
+    }
+    if (
+      this.onQuote != null &&
+      isLocalQuoteTarget &&
+      hasValidQuoteAuthorization
     ) {
       const message = await getMessage();
       if (

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -852,7 +852,15 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     quoteVisibility: MessageVisibility,
     targetVisibility: MessageVisibility,
   ): Promise<boolean> {
-    if (targetVisibility === "unknown") return quoteVisibility !== "direct";
+    if (targetVisibility === "unknown") {
+      return quoteVisibility !== "direct" ||
+        !await this.#isQuoteAudienceSubset(
+          ctx,
+          actorId,
+          quoteObject,
+          targetObject,
+        );
+    }
     if (quoteVisibility === "unknown") {
       return targetVisibility !== "public" && targetVisibility !== "unlisted";
     }

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -714,7 +714,8 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       suppressError: true,
     });
     if (!isMessageObject(instrument) || instrument.id == null) return;
-    if (instrument.quoteUrl?.href !== targetObject.id.href) return;
+    const quotedObjectId = instrument.quoteId ?? instrument.quoteUrl;
+    if (quotedObjectId?.href !== targetObject.id.href) return;
     const actor = await request.getActor({
       contextLoader: ctx.contextLoader,
       documentLoader,

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -899,6 +899,40 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     return true;
   }
 
+  async #getMessageVisibility(
+    ctx: InboxContext<TContextData>,
+    object: Object,
+  ): Promise<MessageVisibility | null> {
+    const documentLoader = await ctx.getDocumentLoader(this);
+    const actor = object.attributionId?.href ===
+        ctx.getActorUri(this.identifier).href
+      ? await this.getSession(ctx).getActor()
+      : await object.getAttribution({
+        contextLoader: ctx.contextLoader,
+        documentLoader,
+        suppressError: true,
+      });
+    if (!isActor(actor)) return null;
+    const mentionedActorIds = new Set<string>();
+    for await (
+      const tag of object.getTags({
+        contextLoader: ctx.contextLoader,
+        documentLoader,
+        suppressError: true,
+      })
+    ) {
+      if (tag instanceof Mention && tag.href != null) {
+        mentionedActorIds.add(tag.href.href);
+      }
+    }
+    return getMessageVisibility(
+      object.toIds,
+      object.ccIds,
+      actor,
+      mentionedActorIds,
+    );
+  }
+
   async #matchesQuoteAcceptance(
     ctx: InboxContext<TContextData>,
     actorId: URL,
@@ -957,10 +991,52 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     const authorization = await this.repository.getQuoteAuthorization(
       parsed.values.id as Uuid,
     );
-    return authorization?.attributionId?.href ===
-        ctx.getActorUri(this.identifier).href &&
-      authorization.interactingObjectId?.href === object.id.href &&
-      authorization.interactionTargetId?.href === targetId.href;
+    if (
+      authorization?.attributionId?.href !==
+        ctx.getActorUri(this.identifier).href ||
+      authorization.interactingObjectId?.href !== object.id.href ||
+      authorization.interactionTargetId?.href !== targetId.href
+    ) {
+      return false;
+    }
+    const parsedTarget = parseLocalUri(
+      ctx,
+      targetId,
+      this.legacyObjectUrisIdentifier,
+    );
+    if (
+      parsedTarget?.type !== "object" ||
+      parsedTarget.values.identifier !== this.identifier
+    ) return false;
+    const stored = await this.repository.getMessage(
+      parsedTarget.values.id as Uuid,
+    );
+    if (!(stored instanceof Create)) return false;
+    const targetObject = await stored.getObject(ctx);
+    if (
+      !isMessageObject(targetObject) || targetObject.id?.href !== targetId.href
+    ) {
+      return false;
+    }
+    const quoteVisibility = await this.#getMessageVisibility(ctx, object);
+    const targetVisibility = await this.#getMessageVisibility(
+      ctx,
+      targetObject,
+    );
+    if (quoteVisibility == null || targetVisibility == null) return false;
+    if (
+      await this.#isQuoteAudienceWider(
+        ctx,
+        object,
+        targetObject,
+        quoteVisibility,
+        targetVisibility,
+      )
+    ) {
+      await this.repository.removeQuoteAuthorization(parsed.values.id as Uuid);
+      return false;
+    }
+    return true;
   }
 
   async onCreated(

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -773,7 +773,6 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     if (
       await this.#isQuoteAudienceWider(
         ctx,
-        actor.id,
         quoteObject,
         targetObject,
         quote.visibility,
@@ -846,7 +845,6 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
 
   async #isQuoteAudienceWider(
     ctx: InboxContext<TContextData>,
-    actorId: URL,
     quoteObject: Object,
     targetObject: Object,
     quoteVisibility: MessageVisibility,
@@ -856,7 +854,6 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       return quoteVisibility !== "direct" ||
         !await this.#isQuoteAudienceSubset(
           ctx,
-          actorId,
           quoteObject,
           targetObject,
         );
@@ -874,7 +871,6 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     if (ranks[quoteVisibility] > ranks[targetVisibility]) return true;
     return !await this.#isQuoteAudienceSubset(
       ctx,
-      actorId,
       quoteObject,
       targetObject,
     );
@@ -882,7 +878,6 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
 
   async #isQuoteAudienceSubset(
     ctx: InboxContext<TContextData>,
-    actorId: URL,
     quoteObject: Object,
     targetObject: Object,
   ): Promise<boolean> {
@@ -892,11 +887,13 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     targetRecipients.add(ctx.getActorUri(this.identifier).href);
     if (targetRecipients.has(PUBLIC_COLLECTION.href)) return true;
     const followerCollection = ctx.getFollowersUri(this.identifier).href;
-    const actorIsFollower = targetRecipients.has(followerCollection) &&
-      await this.repository.hasFollower(actorId);
+    const targetIncludesFollowers = targetRecipients.has(followerCollection);
     for (const recipient of [...quoteObject.toIds, ...quoteObject.ccIds]) {
       if (targetRecipients.has(recipient.href)) continue;
-      if (actorIsFollower && recipient.href === actorId.href) continue;
+      if (
+        targetIncludesFollowers &&
+        await this.repository.hasFollower(recipient)
+      ) continue;
       return false;
     }
     return true;

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -829,16 +829,18 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     quoteVisibility: MessageVisibility,
     targetVisibility: MessageVisibility,
   ): boolean {
-    const ranks: Record<MessageVisibility, number | undefined> = {
+    if (targetVisibility === "unknown") return quoteVisibility !== "direct";
+    if (quoteVisibility === "unknown") {
+      return targetVisibility !== "public" && targetVisibility !== "unlisted";
+    }
+    const ranks: Record<MessageVisibility, number> = {
       public: 4,
       unlisted: 3,
       followers: 2,
       direct: 1,
-      unknown: undefined,
+      unknown: 0,
     };
-    const quoteRank = ranks[quoteVisibility];
-    const targetRank = ranks[targetVisibility];
-    return quoteRank != null && targetRank != null && quoteRank > targetRank;
+    return ranks[quoteVisibility] > ranks[targetVisibility];
   }
 
   async #matchesQuoteAcceptance(

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -697,8 +697,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     );
     if (
       parsedObj?.type !== "object" ||
-      // deno-lint-ignore no-explicit-any
-      !messageClasses.includes(parsedObj.class as any) ||
+      !(messageClasses as readonly unknown[]).includes(parsedObj.class) ||
       parsedObj.values.identifier !== this.identifier
     ) return;
     const stored = await this.repository.getMessage(
@@ -794,6 +793,12 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       quote,
       target,
     );
+    const revokeAndRejectQuoteRequest = async () => {
+      if (existingAuthorization != null) {
+        await target.unauthorizeQuote(quote);
+      }
+      await quoteRequest.reject();
+    };
     const rule = targetObject.interactionPolicy?.canQuote;
     if (rule == null) {
       const policy = normalizeQuotePolicy(this.quotePolicy);
@@ -804,7 +809,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       ) {
         // Leave pending for the event handler below.
       } else {
-        await quoteRequest.reject();
+        await revokeAndRejectQuoteRequest();
       }
     } else if (
       await this.#matchesQuoteApprovals(ctx, actor.id, rule.automaticApprovals)
@@ -815,7 +820,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     ) {
       // Leave pending for the event handler below.
     } else {
-      await quoteRequest.reject();
+      await revokeAndRejectQuoteRequest();
     }
     await this.onQuoteRequest?.(session, quoteRequest);
   }

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -47,8 +47,10 @@ import {
   PropertyValue,
   PUBLIC_COLLECTION,
   Question,
+  type QuoteAuthorization,
+  type QuoteRequest as RawQuoteRequest,
   type Recipient,
-  type Reject,
+  Reject,
   Service,
   type Undo,
   Update,
@@ -73,6 +75,7 @@ import type {
   MentionEventHandler,
   MessageEventHandler,
   QuoteEventHandler,
+  QuoteRequestEventHandler,
   ReactionEventHandler,
   RejectEventHandler,
   ReplyEventHandler,
@@ -93,6 +96,8 @@ import {
 } from "./message-impl.ts";
 import type { Message, MessageClass, SharedMessage } from "./message.ts";
 import type { Vote } from "./poll.ts";
+import { QuoteRequestImpl } from "./quote-impl.ts";
+import { normalizeQuotePolicy, type QuotePolicyOption } from "./quote.ts";
 import type { Like, Reaction } from "./reaction.ts";
 import {
   ActorScopedRepository,
@@ -137,6 +142,7 @@ export const botEventHandlerNames = [
   "onMention",
   "onReply",
   "onQuote",
+  "onQuoteRequest",
   "onMessage",
   "onSharedMessage",
   "onLike",
@@ -158,6 +164,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
   readonly properties: Record<string, Text<"block" | "inline", TContextData>>;
   #properties: { pairs: PropertyValue[]; tags: (Link | Object)[] } | null;
   readonly followerPolicy: "accept" | "reject" | "manual";
+  readonly quotePolicy: QuotePolicyOption;
   readonly repository: ActorScopedRepository;
 
   /**
@@ -208,6 +215,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
   onMention?: MentionEventHandler<TContextData>;
   onReply?: ReplyEventHandler<TContextData>;
   onQuote?: QuoteEventHandler<TContextData>;
+  onQuoteRequest?: QuoteRequestEventHandler<TContextData>;
   onMessage?: MessageEventHandler<TContextData>;
   onSharedMessage?: SharedMessageEventHandler<TContextData>;
   onLike?: LikeEventHandler<TContextData>;
@@ -228,6 +236,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     this.properties = options.properties ?? {};
     this.#properties = null;
     this.followerPolicy = options.followerPolicy ?? "accept";
+    this.quotePolicy = options.quotePolicy ?? "public";
     this.instance = options.instance ?? new InstanceImpl({
       kv: options.kv,
       // The single-bot deployment may carry data from BotKit 0.4 or
@@ -531,6 +540,15 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     return isVisible(activity) ? activity : null;
   }
 
+  async dispatchQuoteAuthorization(
+    _ctx: RequestContext<TContextData>,
+    values: { identifier: string; id: string },
+  ): Promise<QuoteAuthorization | null> {
+    if (values.identifier !== this.identifier) return null;
+    return await this.repository.getQuoteAuthorization(values.id as Uuid) ??
+      null;
+  }
+
   dispatchEmoji(
     ctx: Context<TContextData>,
     values: { name: string },
@@ -659,6 +677,141 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       const session = this.getSession(ctx);
       await this.onRejectFollow(session, followee);
     }
+  }
+
+  async onQuoteRequested(
+    ctx: InboxContext<TContextData>,
+    request: RawQuoteRequest,
+  ): Promise<void> {
+    if (request.actorId == null) return;
+    const parsedObj = parseLocalUri(
+      ctx,
+      request.objectId,
+      this.legacyObjectUrisIdentifier,
+    );
+    if (
+      parsedObj?.type !== "object" ||
+      // deno-lint-ignore no-explicit-any
+      !messageClasses.includes(parsedObj.class as any) ||
+      parsedObj.values.identifier !== this.identifier
+    ) return;
+    const stored = await this.repository.getMessage(
+      parsedObj.values.id as Uuid,
+    );
+    if (!(stored instanceof Create)) return;
+    const targetObject = await stored.getObject(ctx);
+    if (!isMessageObject(targetObject)) return;
+    const documentLoader = await ctx.getDocumentLoader(this);
+    const instrument = await request.getInstrument({
+      contextLoader: ctx.contextLoader,
+      documentLoader,
+      suppressError: true,
+    });
+    if (!isMessageObject(instrument)) return;
+    const actor = await request.getActor({
+      contextLoader: ctx.contextLoader,
+      documentLoader,
+      suppressError: true,
+    });
+    if (!isActor(actor) || actor.id == null) return;
+    const session = this.getSession(ctx);
+    if (
+      instrument.attributionId != null &&
+      instrument.attributionId.href !== actor.id.href
+    ) {
+      await session.context.sendActivity(
+        this,
+        actor,
+        new Reject({
+          id: new URL(`/#reject/${request.id?.href}`, session.actorId),
+          actor: session.actorId,
+          to: actor.id,
+          object: request,
+        }),
+        { excludeBaseUris: [new URL(session.context.origin)] },
+      );
+      return;
+    }
+    const quoteObject = instrument.attributionId == null
+      ? instrument.clone({ attribution: actor.id })
+      : instrument;
+    const target = await createMessage(
+      targetObject,
+      session,
+      {},
+      undefined,
+      undefined,
+      true,
+    );
+    const quote = await createMessage(quoteObject, session, {
+      [actor.id.href]: actor,
+    });
+    const quoteRequest = new QuoteRequestImpl(
+      session,
+      request,
+      actor,
+      quote,
+      target,
+    );
+    const rule = targetObject.interactionPolicy?.canQuote;
+    if (rule == null) {
+      const policy = normalizeQuotePolicy(this.quotePolicy);
+      if (await this.#matchesQuoteAcceptance(ctx, actor.id, policy.automatic)) {
+        await quoteRequest.accept();
+      } else if (
+        await this.#matchesQuoteAcceptance(ctx, actor.id, policy.manual)
+      ) {
+        // Leave pending for the event handler below.
+      } else {
+        await quoteRequest.reject();
+      }
+    } else if (
+      await this.#matchesQuoteApprovals(ctx, actor.id, rule.automaticApprovals)
+    ) {
+      await quoteRequest.accept();
+    } else if (
+      await this.#matchesQuoteApprovals(ctx, actor.id, rule.manualApprovals)
+    ) {
+      // Leave pending for the event handler below.
+    } else {
+      await quoteRequest.reject();
+    }
+    await this.onQuoteRequest?.(session, quoteRequest);
+  }
+
+  async #matchesQuoteAcceptance(
+    ctx: InboxContext<TContextData>,
+    actorId: URL,
+    acceptance: ReturnType<typeof normalizeQuotePolicy>["automatic"],
+  ): Promise<boolean> {
+    if (actorId.href === ctx.getActorUri(this.identifier).href) return true;
+    switch (acceptance) {
+      case "public":
+        return true;
+      case "followers":
+        return await this.repository.hasFollower(actorId);
+      case "nobody":
+      default:
+        return false;
+    }
+  }
+
+  async #matchesQuoteApprovals(
+    ctx: InboxContext<TContextData>,
+    actorId: URL,
+    approvals: readonly URL[],
+  ): Promise<boolean> {
+    if (actorId.href === ctx.getActorUri(this.identifier).href) return true;
+    const followerCollection = ctx.getFollowersUri(this.identifier).href;
+    for (const approval of approvals) {
+      if (approval.href === PUBLIC_COLLECTION.href) return true;
+      if (approval.href === actorId.href) return true;
+      if (
+        approval.href === followerCollection &&
+        await this.repository.hasFollower(actorId)
+      ) return true;
+    }
+    return false;
   }
 
   async onCreated(
@@ -1207,6 +1360,12 @@ export function wrapBotImpl<TContextData>(
     set onQuote(value) {
       bot.onQuote = value;
     },
+    get onQuoteRequest() {
+      return bot.onQuoteRequest;
+    },
+    set onQuoteRequest(value) {
+      bot.onQuoteRequest = value;
+    },
     get onMessage() {
       return bot.onMessage;
     },
@@ -1429,6 +1588,46 @@ export class MigrationGatedRepository implements Repository {
     yield* this.#repository.findFollowedBots(followeeId);
   }
 
+  async addQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+    authorization: QuoteAuthorization,
+  ): Promise<void> {
+    await this.#migration;
+    return await this.#repository.addQuoteAuthorization(
+      identifier,
+      id,
+      authorization,
+    );
+  }
+
+  async getQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    await this.#migration;
+    return await this.#repository.getQuoteAuthorization(identifier, id);
+  }
+
+  async findQuoteAuthorization(
+    identifier: string,
+    interactingObject: URL,
+  ): Promise<QuoteAuthorization | undefined> {
+    await this.#migration;
+    return await this.#repository.findQuoteAuthorization(
+      identifier,
+      interactingObject,
+    );
+  }
+
+  async removeQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    await this.#migration;
+    return await this.#repository.removeQuoteAuthorization(identifier, id);
+  }
+
   async vote(
     identifier: string,
     messageId: Uuid,
@@ -1482,6 +1681,7 @@ export class BotGroupImpl<TContextData> implements BotGroup<TContextData> {
   onMention?: MentionEventHandler<TContextData>;
   onReply?: ReplyEventHandler<TContextData>;
   onQuote?: QuoteEventHandler<TContextData>;
+  onQuoteRequest?: QuoteRequestEventHandler<TContextData>;
   onMessage?: MessageEventHandler<TContextData>;
   onSharedMessage?: SharedMessageEventHandler<TContextData>;
   onLike?: LikeEventHandler<TContextData>;
@@ -1549,6 +1749,7 @@ export class GroupBotImpl<TContextData> extends BotImpl<TContextData> {
       image: profile.image,
       properties: profile.properties,
       followerPolicy: profile.followerPolicy,
+      quotePolicy: profile.quotePolicy,
     });
     this.group = group;
     for (const name of botEventHandlerNames) {

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -47,7 +47,7 @@ import {
   PropertyValue,
   PUBLIC_COLLECTION,
   Question,
-  type QuoteAuthorization,
+  QuoteAuthorization,
   type QuoteRequest as RawQuoteRequest,
   type Recipient,
   Reject,
@@ -934,6 +934,35 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     return false;
   }
 
+  async #hasValidQuoteAuthorization(
+    ctx: InboxContext<TContextData>,
+    object: Object,
+    targetId: URL,
+  ): Promise<boolean> {
+    if (
+      object.id == null ||
+      !("quoteAuthorizationId" in object) ||
+      !(object.quoteAuthorizationId instanceof URL)
+    ) return false;
+    const parsed = parseLocalUri(
+      ctx,
+      object.quoteAuthorizationId,
+      this.legacyObjectUrisIdentifier,
+    );
+    if (
+      parsed?.type !== "object" ||
+      parsed.class !== QuoteAuthorization ||
+      parsed.values.identifier !== this.identifier
+    ) return false;
+    const authorization = await this.repository.getQuoteAuthorization(
+      parsed.values.id as Uuid,
+    );
+    return authorization?.attributionId?.href ===
+        ctx.getActorUri(this.identifier).href &&
+      authorization.interactingObjectId?.href === object.id.href &&
+      authorization.interactionTargetId?.href === targetId.href;
+  }
+
   async onCreated(
     ctx: InboxContext<TContextData>,
     create: Create,
@@ -1109,7 +1138,9 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
         break;
       }
     }
-    if (quoteUrl == null) quoteUrl = object.quoteId ?? object.quoteUrl;
+    const fepQuoteUrl = object.quoteId;
+    const requiresQuoteAuthorization = quoteUrl == null && fepQuoteUrl != null;
+    if (quoteUrl == null) quoteUrl = fepQuoteUrl ?? object.quoteUrl;
     const quoteTarget = parseLocalUri(
       ctx,
       quoteUrl,
@@ -1120,7 +1151,10 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       quoteTarget?.type === "object" &&
       // @ts-ignore: quoteTarget.class satisfies (typeof messageClasses)[number]
       messageClasses.includes(quoteTarget.class) &&
-      quoteTarget.values.identifier === this.identifier
+      quoteTarget.values.identifier === this.identifier &&
+      (!requiresQuoteAuthorization ||
+        (fepQuoteUrl != null &&
+          await this.#hasValidQuoteAuthorization(ctx, object, fepQuoteUrl)))
     ) {
       const message = await getMessage();
       if (

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -689,6 +689,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     request: RawQuoteRequest,
   ): Promise<void> {
     if (request.id == null || request.actorId == null) return;
+    const requestId = request.id;
     const parsedObj = parseLocalUri(
       ctx,
       request.objectId,
@@ -723,21 +724,24 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     if (!await this.#canActorSeeObject(ctx, actor.id, targetObject)) {
       return;
     }
-    if (
-      instrument.attributionId != null &&
-      instrument.attributionId.href !== actor.id.href
-    ) {
+    const rejectRequest = async () => {
       await session.context.sendActivity(
         this,
         actor,
         new Reject({
-          id: new URL(`/#reject/${request.id?.href}`, session.actorId),
+          id: new URL(`/#reject/${requestId.href}`, session.actorId),
           actor: session.actorId,
           to: actor.id,
           object: request,
         }),
         { excludeBaseUris: [new URL(session.context.origin)] },
       );
+    };
+    if (
+      instrument.attributionId != null &&
+      instrument.attributionId.href !== actor.id.href
+    ) {
+      await rejectRequest();
       return;
     }
     const quoteObject = instrument.attributionId == null
@@ -754,6 +758,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     const quote = await createMessage(quoteObject, session, {
       [actor.id.href]: actor,
     });
+    if (quote.id == null || target.id == null) return;
     const existingAuthorization = await this.repository.findQuoteAuthorization(
       quote.id,
     );
@@ -761,34 +766,14 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       existingAuthorization != null &&
       existingAuthorization.interactionTargetId?.href !== target.id.href
     ) {
-      await session.context.sendActivity(
-        this,
-        actor,
-        new Reject({
-          id: new URL(`/#reject/${request.id.href}`, session.actorId),
-          actor: session.actorId,
-          to: actor.id,
-          object: request,
-        }),
-        { excludeBaseUris: [new URL(session.context.origin)] },
-      );
+      await rejectRequest();
       return;
     }
     if (this.#isQuoteAudienceWider(quote.visibility, target.visibility)) {
       if (existingAuthorization != null) {
         await target.unauthorizeQuote(quote);
       }
-      await session.context.sendActivity(
-        this,
-        actor,
-        new Reject({
-          id: new URL(`/#reject/${request.id?.href}`, session.actorId),
-          actor: session.actorId,
-          to: actor.id,
-          object: request,
-        }),
-        { excludeBaseUris: [new URL(session.context.origin)] },
-      );
+      await rejectRequest();
       return;
     }
     const quoteRequest = new QuoteRequestImpl(

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -807,7 +807,10 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       } else if (
         await this.#matchesQuoteAcceptance(ctx, actor.id, policy.manual)
       ) {
-        // Leave pending for the event handler below.
+        if (existingAuthorization != null) {
+          await quoteRequest.accept();
+          return;
+        }
       } else {
         await revokeAndRejectQuoteRequest();
       }
@@ -818,7 +821,10 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     } else if (
       await this.#matchesQuoteApprovals(ctx, actor.id, rule.manualApprovals)
     ) {
-      // Leave pending for the event handler below.
+      if (existingAuthorization != null) {
+        await quoteRequest.accept();
+        return;
+      }
     } else {
       await revokeAndRejectQuoteRequest();
     }
@@ -1098,7 +1104,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
         break;
       }
     }
-    if (quoteUrl == null) quoteUrl = object.quoteUrl;
+    if (quoteUrl == null) quoteUrl = object.quoteId ?? object.quoteUrl;
     const quoteTarget = parseLocalUri(
       ctx,
       quoteUrl,

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -1140,7 +1140,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     }
     const fepQuoteUrl = object.quoteId;
     const requiresQuoteAuthorization = fepQuoteUrl != null;
-    if (quoteUrl == null) quoteUrl = fepQuoteUrl ?? object.quoteUrl;
+    quoteUrl = fepQuoteUrl ?? quoteUrl ?? object.quoteUrl;
     const quoteTarget = parseLocalUri(
       ctx,
       quoteUrl,

--- a/packages/botkit/src/bot.ts
+++ b/packages/botkit/src/bot.ts
@@ -30,6 +30,7 @@ import type {
   MentionEventHandler,
   MessageEventHandler,
   QuoteEventHandler,
+  QuoteRequestEventHandler,
   ReactionEventHandler,
   RejectEventHandler,
   ReplyEventHandler,
@@ -39,6 +40,7 @@ import type {
   UnlikeEventHandler,
   VoteEventHandler,
 } from "./events.ts";
+import type { QuotePolicyOption } from "./quote.ts";
 import type { Repository } from "./repository.ts";
 import type { Session } from "./session.ts";
 import type { Text } from "./text.ts";
@@ -87,6 +89,12 @@ export interface BotEventHandlers<TContextData> {
    * @since 0.2.0
    */
   onQuote?: QuoteEventHandler<TContextData>;
+
+  /**
+   * An event handler for a quote request to the bot.
+   * @since 0.5.0
+   */
+  onQuoteRequest?: QuoteRequestEventHandler<TContextData>;
 
   /**
    * An event handler for a message shown to the bot's timeline.  To listen
@@ -180,6 +188,12 @@ export interface ReadonlyBot {
    * How the bot handles incoming follow requests.
    */
   readonly followerPolicy: "accept" | "reject" | "manual";
+
+  /**
+   * How the bot handles incoming quote requests for its messages.
+   * @since 0.5.0
+   */
+  readonly quotePolicy: QuotePolicyOption;
 }
 
 /**
@@ -349,6 +363,16 @@ export interface CreateBotOptions<TContextData> {
    * @default `"accept"`
    */
   readonly followerPolicy?: "accept" | "reject" | "manual";
+
+  /**
+   * Who can quote messages published by the bot.
+   *
+   * This policy is advertised on outgoing messages and is used as the
+   * fallback for older messages that do not have a serialized quote policy.
+   * @default `"public"`
+   * @since 0.5.0
+   */
+  readonly quotePolicy?: QuotePolicyOption;
 
   /**
    * The underlying key-value store to use for storing data.

--- a/packages/botkit/src/events.ts
+++ b/packages/botkit/src/events.ts
@@ -17,6 +17,7 @@ import type { Actor } from "@fedify/vocab";
 import type { FollowRequest } from "./follow.ts";
 import type { Message, MessageClass, SharedMessage } from "./message.ts";
 import type { Vote } from "./poll.ts";
+import type { QuoteRequest } from "./quote.ts";
 import type { Like, Reaction } from "./reaction.ts";
 import type { Session } from "./session.ts";
 
@@ -96,6 +97,18 @@ export type ReplyEventHandler<TContextData> = (
 export type QuoteEventHandler<TContextData> = (
   session: Session<TContextData>,
   quote: Message<MessageClass, TContextData>,
+) => void | Promise<void>;
+
+/**
+ * An event handler for a quote request to the bot.
+ * @typeParam TContextData The type of the context data.
+ * @param session The session of the bot.
+ * @param quoteRequest The quote request.
+ * @since 0.5.0
+ */
+export type QuoteRequestEventHandler<TContextData> = (
+  session: Session<TContextData>,
+  quoteRequest: QuoteRequest<TContextData>,
 ) => void | Promise<void>;
 
 /**

--- a/packages/botkit/src/instance-impl.test.ts
+++ b/packages/botkit/src/instance-impl.test.ts
@@ -14,9 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import { MemoryKvStore } from "@fedify/fedify/federation";
+import { Create, Note } from "@fedify/vocab";
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { createInstance } from "./instance.ts";
+import { MemoryRepository } from "./repository.ts";
+import { text } from "./text.ts";
 
 describe("createInstance()", () => {
   test("serves a static bot's actor", async () => {
@@ -49,6 +52,35 @@ describe("createInstance()", () => {
     assert.deepStrictEqual(response.status, 200);
     const jrd = await response.json();
     assert.deepStrictEqual(jrd.subject, "acct:mybot@example.com");
+  });
+
+  test("passes quotePolicy to a static bot", async () => {
+    const repository = new MemoryRepository();
+    const instance = createInstance<void>({
+      kv: new MemoryKvStore(),
+      repository,
+    });
+    const bot = instance.createBot("bot", {
+      username: "mybot",
+      quotePolicy: "nobody",
+    });
+    const session = bot.getSession("https://example.com");
+
+    await session.publish(text`Nobody can quote this.`);
+
+    const messages = [];
+    for await (const message of repository.getMessages("bot")) {
+      messages.push(message);
+    }
+    assert.deepStrictEqual(messages.length, 1);
+    const activity = messages[0];
+    assert.ok(activity instanceof Create);
+    const object = await activity.getObject(session.context);
+    assert.ok(object instanceof Note);
+    assert.deepStrictEqual(
+      object.interactionPolicy?.canQuote?.automaticApprovals,
+      [session.actorId],
+    );
   });
 
   test("returns 404 for unregistered identifiers", async () => {

--- a/packages/botkit/src/instance-impl.ts
+++ b/packages/botkit/src/instance-impl.ts
@@ -473,6 +473,7 @@ export class InstanceImpl<TContextData>
       image: profile.image,
       properties: profile.properties,
       followerPolicy: profile.followerPolicy,
+      quotePolicy: profile.quotePolicy,
     });
     return wrapBotImpl(bot);
   }

--- a/packages/botkit/src/instance-impl.ts
+++ b/packages/botkit/src/instance-impl.ts
@@ -43,6 +43,8 @@ import {
   Mention,
   Note,
   Question,
+  QuoteAuthorization,
+  QuoteRequest,
   Reject,
   Undo,
 } from "@fedify/vocab";
@@ -297,6 +299,14 @@ export class InstanceImpl<TContextData>
       },
     );
     this.federation.setObjectDispatcher(
+      QuoteAuthorization,
+      "/ap/actor/{identifier}/quote-authorization/{id}",
+      async (ctx, values) => {
+        const bot = await this.resolveBot(ctx, values.identifier);
+        return await bot?.dispatchQuoteAuthorization(ctx, values) ?? null;
+      },
+    );
+    this.federation.setObjectDispatcher(
       APEmoji,
       "/ap/emoji/{name}",
       (ctx, values) => this.dispatchEmoji(ctx, values),
@@ -307,6 +317,7 @@ export class InstanceImpl<TContextData>
         this.onUnverifiedActivity(ctx, activity, reason)
       )
       .on(Follow, (ctx, follow) => this.onFollowed(ctx, follow))
+      .on(QuoteRequest, (ctx, request) => this.onQuoteRequested(ctx, request))
       .on(Undo, (ctx, undo) => this.onUndone(ctx, undo))
       .on(Accept, (ctx, accept) => this.onFollowAccepted(ctx, accept))
       .on(Reject, (ctx, reject) => this.onFollowRejected(ctx, reject))
@@ -618,6 +629,17 @@ export class InstanceImpl<TContextData>
         { undoId: undo.id?.href, object },
       );
     }
+  }
+
+  async onQuoteRequested(
+    ctx: InboxContext<TContextData>,
+    request: QuoteRequest,
+  ): Promise<void> {
+    const bots = await this.#resolveTargets(
+      ctx,
+      () => this.#localObjectTarget(ctx, request.objectId),
+    );
+    for (const bot of bots) await bot.onQuoteRequested(ctx, request);
   }
 
   async onFollowAccepted(

--- a/packages/botkit/src/instance-impl.ts
+++ b/packages/botkit/src/instance-impl.ts
@@ -47,6 +47,7 @@ import {
   QuoteRequest,
   Reject,
   Undo,
+  Update,
 } from "@fedify/vocab";
 import { getLogger } from "@logtape/logtape";
 import mimeDb from "mime-db";
@@ -322,6 +323,7 @@ export class InstanceImpl<TContextData>
       .on(Accept, (ctx, accept) => this.onFollowAccepted(ctx, accept))
       .on(Reject, (ctx, reject) => this.onFollowRejected(ctx, reject))
       .on(Create, (ctx, create) => this.onCreated(ctx, create))
+      .on(Update, (ctx, update) => this.onUpdated(ctx, update))
       .on(Announce, (ctx, announce) => this.onAnnounced(ctx, announce))
       .on(RawLike, (ctx, like) => this.onLiked(ctx, like))
       .setSharedKeyDispatcher((ctx) => this.dispatchSharedKey(ctx));
@@ -736,6 +738,32 @@ export class InstanceImpl<TContextData>
       return targets;
     });
     for (const bot of bots) await bot.onCreated(ctx, create);
+  }
+
+  async onUpdated(
+    ctx: InboxContext<TContextData>,
+    update: Update,
+  ): Promise<void> {
+    const bots = await this.#resolveTargets(ctx, async () => {
+      const targets = new Set<string>();
+      const addLocalObject = (uri: URL | null) => {
+        const parsed = parseLocalUri(
+          ctx,
+          uri,
+          this.legacyObjectUrisIdentifier,
+        );
+        if (
+          parsed?.type === "object" &&
+          typeof parsed.values.identifier === "string"
+        ) {
+          targets.add(parsed.values.identifier);
+        }
+      };
+      const object = await update.getObject(ctx);
+      if (isMessageObject(object)) addLocalObject(object.quoteId);
+      return targets;
+    });
+    for (const bot of bots) await bot.onUpdated(ctx, update);
   }
 
   async onAnnounced(

--- a/packages/botkit/src/instance-impl.ts
+++ b/packages/botkit/src/instance-impl.ts
@@ -728,6 +728,7 @@ export class InstanceImpl<TContextData>
             addLocalObject(tag.href);
           }
         }
+        addLocalObject(object.quoteId);
         addLocalObject(object.quoteUrl);
         // Bots whose message is replied to:
         addLocalObject(object.replyTargetId);

--- a/packages/botkit/src/instance-routing.test.ts
+++ b/packages/botkit/src/instance-routing.test.ts
@@ -25,6 +25,7 @@ import {
   PUBLIC_COLLECTION,
   QuoteAuthorization,
   Undo,
+  Update,
 } from "@fedify/vocab";
 import assert from "node:assert";
 import { describe, test } from "node:test";
@@ -404,6 +405,72 @@ describe("shared inbox routing", () => {
           attribution: author,
           to: PUBLIC_COLLECTION,
           content: "A pure FEP quote",
+          quote: targetId,
+          quoteAuthorization: authorizationUrl,
+        }),
+      }),
+    );
+    assert.deepStrictEqual(events, ["quote:alpha"]);
+  });
+
+  test("routes pure FEP quote Updates to the quoted bot", async () => {
+    const { instance, repository, alpha, ctx } = createHarness();
+    const events: string[] = [];
+    alpha.onQuote = (session) =>
+      void (events.push(`quote:${session.bot.identifier}`));
+
+    const targetMessageId = "01950000-0000-7000-8000-000000000303" as Uuid;
+    const targetId = new URL(
+      `https://example.com/ap/actor/alpha/note/${targetMessageId}`,
+    );
+    const quoteId = new URL("https://remote.example/notes/fep-quote-update");
+    await repository.addMessage(
+      "alpha",
+      targetMessageId,
+      new Create({
+        id: new URL(
+          `https://example.com/ap/actor/alpha/create/${targetMessageId}`,
+        ),
+        actor: new URL("https://example.com/ap/actor/alpha"),
+        to: PUBLIC_COLLECTION,
+        object: new Note({
+          id: targetId,
+          attribution: new URL("https://example.com/ap/actor/alpha"),
+          to: PUBLIC_COLLECTION,
+          content: "Alpha's quoteable post",
+        }),
+      }),
+    );
+    const authorizationId = "01950000-0000-7000-8000-000000000304" as Uuid;
+    const authorizationUrl = new URL(
+      `https://example.com/ap/actor/alpha/quote-authorization/${authorizationId}`,
+    );
+    await repository.addQuoteAuthorization(
+      "alpha",
+      authorizationId,
+      new QuoteAuthorization({
+        id: authorizationUrl,
+        attribution: new URL("https://example.com/ap/actor/alpha"),
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+    );
+
+    const author = new Person({
+      id: new URL("https://remote.example/actors/john"),
+      preferredUsername: "john",
+    });
+    await instance.onUpdated(
+      ctx,
+      new Update({
+        id: new URL("https://remote.example/updates/fep-quote"),
+        actor: author,
+        to: PUBLIC_COLLECTION,
+        object: new Note({
+          id: quoteId,
+          attribution: author,
+          to: PUBLIC_COLLECTION,
+          content: "A pure FEP quote update",
           quote: targetId,
           quoteAuthorization: authorizationUrl,
         }),

--- a/packages/botkit/src/instance-routing.test.ts
+++ b/packages/botkit/src/instance-routing.test.ts
@@ -23,6 +23,7 @@ import {
   Note,
   Person,
   PUBLIC_COLLECTION,
+  QuoteAuthorization,
   Undo,
 } from "@fedify/vocab";
 import assert from "node:assert";
@@ -341,6 +342,56 @@ describe("shared inbox routing", () => {
       }),
     );
     assert.deepStrictEqual(events, ["mention:beta"]);
+  });
+
+  test("routes pure FEP quote Creates to the quoted bot", async () => {
+    const { instance, repository, alpha, beta, ctx } = createHarness();
+    const events: string[] = [];
+    alpha.onQuote = (session) =>
+      void (events.push(`quote:${session.bot.identifier}`));
+    beta.onQuote = (session) =>
+      void (events.push(`quote:${session.bot.identifier}`));
+
+    const quoteId = new URL("https://remote.example/notes/fep-quote");
+    const targetId = new URL(
+      "https://example.com/ap/actor/alpha/note/01950000-0000-7000-8000-000000000301",
+    );
+    const authorizationId = "01950000-0000-7000-8000-000000000302" as Uuid;
+    const authorizationUrl = new URL(
+      `https://example.com/ap/actor/alpha/quote-authorization/${authorizationId}`,
+    );
+    await repository.addQuoteAuthorization(
+      "alpha",
+      authorizationId,
+      new QuoteAuthorization({
+        id: authorizationUrl,
+        attribution: new URL("https://example.com/ap/actor/alpha"),
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+    );
+
+    const author = new Person({
+      id: new URL("https://remote.example/actors/john"),
+      preferredUsername: "john",
+    });
+    await instance.onCreated(
+      ctx,
+      new Create({
+        id: new URL("https://remote.example/creates/fep-quote"),
+        actor: author,
+        to: PUBLIC_COLLECTION,
+        object: new Note({
+          id: quoteId,
+          attribution: author,
+          to: PUBLIC_COLLECTION,
+          content: "A pure FEP quote",
+          quote: targetId,
+          quoteAuthorization: authorizationUrl,
+        }),
+      }),
+    );
+    assert.deepStrictEqual(events, ["quote:alpha"]);
   });
 
   test("routes Create to followers of the author", async () => {

--- a/packages/botkit/src/instance-routing.test.ts
+++ b/packages/botkit/src/instance-routing.test.ts
@@ -356,6 +356,24 @@ describe("shared inbox routing", () => {
     const targetId = new URL(
       "https://example.com/ap/actor/alpha/note/01950000-0000-7000-8000-000000000301",
     );
+    const targetMessageId = "01950000-0000-7000-8000-000000000301" as Uuid;
+    await repository.addMessage(
+      "alpha",
+      targetMessageId,
+      new Create({
+        id: new URL(
+          `https://example.com/ap/actor/alpha/create/${targetMessageId}`,
+        ),
+        actor: new URL("https://example.com/ap/actor/alpha"),
+        to: PUBLIC_COLLECTION,
+        object: new Note({
+          id: targetId,
+          attribution: new URL("https://example.com/ap/actor/alpha"),
+          to: PUBLIC_COLLECTION,
+          content: "Alpha's quoteable post",
+        }),
+      }),
+    );
     const authorizationId = "01950000-0000-7000-8000-000000000302" as Uuid;
     const authorizationUrl = new URL(
       `https://example.com/ap/actor/alpha/quote-authorization/${authorizationId}`,

--- a/packages/botkit/src/instance.ts
+++ b/packages/botkit/src/instance.ts
@@ -25,6 +25,7 @@ import type { Bot, BotEventHandlers, PagesOptions } from "./bot.ts";
 import type { CustomEmoji, DeferredCustomEmoji } from "./emoji.ts";
 import { InstanceImpl } from "./instance-impl.ts";
 export { DEFAULT_INSTANCE_ACTOR_IDENTIFIER } from "./instance-impl.ts";
+import type { QuotePolicyOption } from "./quote.ts";
 import type { Repository } from "./repository.ts";
 import type { Session } from "./session.ts";
 import type { Text } from "./text.ts";
@@ -93,6 +94,16 @@ export interface BotProfile<TContextData> {
    * @default `"accept"`
    */
   readonly followerPolicy?: "accept" | "reject" | "manual";
+
+  /**
+   * Who can quote messages published by the bot.
+   *
+   * This policy is advertised on outgoing messages and is used as the
+   * fallback for older messages that do not have a serialized quote policy.
+   * @default `"public"`
+   * @since 0.5.0
+   */
+  readonly quotePolicy?: QuotePolicyOption;
 }
 
 /**

--- a/packages/botkit/src/message-impl.test.ts
+++ b/packages/botkit/src/message-impl.test.ts
@@ -595,6 +595,27 @@ test("AuthorizedMessage.update()", async (t) => {
       }
     });
   }
+
+  await t.test("quote policy", async () => {
+    const repository = new MemoryRepository();
+    const bot = new BotImpl<void>({
+      kv: new MemoryKvStore(),
+      repository,
+      username: "bot",
+    });
+    const ctx = createMockContext(bot, "https://example.com");
+    const session = new SessionImpl(bot, ctx);
+    const msg = await session.publish(text`Hello`);
+    await msg.update(text`Hello again`, { quotePolicy: "nobody" });
+    const [create] = await Array.fromAsync(repository.getMessages("bot"));
+    assert.ok(create instanceof Create);
+    const object = await create.getObject(ctx);
+    assert.ok(object instanceof Note);
+    assert.deepStrictEqual(
+      object.interactionPolicy?.canQuote?.automaticApprovals,
+      [ctx.getActorUri(bot.identifier)],
+    );
+  });
 });
 
 test("getMessageVisibility()", () => {

--- a/packages/botkit/src/message-impl.ts
+++ b/packages/botkit/src/message-impl.ts
@@ -33,6 +33,7 @@ import {
   type Object,
   PUBLIC_COLLECTION,
   Question,
+  QuoteAuthorization,
   Tombstone,
   Undo,
   Update,
@@ -44,6 +45,7 @@ import xss from "xss";
 import type { DeferredCustomEmoji, Emoji } from "./emoji.ts";
 import type {
   AuthorizedMessage,
+  AuthorizedMessageUpdateOptions,
   AuthorizedSharedMessage,
   Message,
   MessageClass,
@@ -52,6 +54,7 @@ import type {
 } from "./message.ts";
 import type { AuthorizedLike, AuthorizedReaction } from "./reaction.ts";
 import type { Uuid } from "./repository.ts";
+import { serializeQuotePolicy } from "./quote.ts";
 import type { SessionImpl } from "./session-impl.ts";
 import type {
   SessionPublishOptions,
@@ -376,7 +379,10 @@ export class MessageImpl<T extends MessageClass, TContextData>
 export class AuthorizedMessageImpl<T extends MessageClass, TContextData>
   extends MessageImpl<T, TContextData>
   implements AuthorizedMessage<T, TContextData> {
-  async update(text: Text<"block", TContextData>): Promise<void> {
+  async update(
+    text: Text<"block", TContextData>,
+    options: AuthorizedMessageUpdateOptions = {},
+  ): Promise<void> {
     const parsed = parseLocalUri(
       this.session.context,
       this.id,
@@ -459,6 +465,15 @@ export class AuthorizedMessageImpl<T extends MessageClass, TContextData>
             ? [PUBLIC_COLLECTION]
             : [],
           updated,
+          interactionPolicy: options.quotePolicy == null
+            ? message.interactionPolicy
+            : serializeQuotePolicy(
+              options.quotePolicy,
+              this.session.actorId,
+              this.session.context.getFollowersUri(
+                this.session.bot.identifier,
+              ),
+            ),
         });
         this.raw = newMessage as T;
         create = create.clone({ object: newMessage, updated });
@@ -596,6 +611,84 @@ export class AuthorizedMessageImpl<T extends MessageClass, TContextData>
       );
     }
   }
+
+  async unauthorizeQuote(
+    quote: Message<MessageClass, TContextData> | URL,
+  ): Promise<void> {
+    const quoteId = quote instanceof URL ? quote : quote.id;
+    const authorization = await this.session.bot.repository
+      .findQuoteAuthorization(quoteId);
+    if (authorization == null || authorization.id == null) {
+      throw new TypeError("The quote authorization does not exist.");
+    }
+    if (authorization.interactionTargetId?.href !== this.id.href) {
+      throw new TypeError(
+        "The quote authorization does not belong to this message.",
+      );
+    }
+    const parsed = parseLocalUri(
+      this.session.context,
+      authorization.id,
+      this.session.bot.legacyObjectUrisIdentifier,
+    );
+    if (
+      parsed?.type !== "object" ||
+      parsed.class !== QuoteAuthorization ||
+      parsed.values.identifier !== this.session.bot.identifier
+    ) {
+      throw new TypeError("The quote authorization is not local.");
+    }
+    await this.session.bot.repository.removeQuoteAuthorization(
+      parsed.values.id as Uuid,
+    );
+    const quoteActor = quote instanceof URL
+      ? await this.#getQuoteActor(quote).catch(() => undefined)
+      : quote.actor;
+    const followersUri = this.session.context.getFollowersUri(
+      this.session.bot.identifier,
+    );
+    const del = new Delete({
+      id: new URL("#delete", authorization.id),
+      actor: this.session.actorId,
+      object: authorization.id,
+      to: quoteActor?.id ?? followersUri,
+      cc: quoteActor?.id == null ? undefined : followersUri,
+    });
+    if (quoteActor?.id != null) {
+      await this.session.context.sendActivity(
+        this.session.bot,
+        quoteActor,
+        del,
+        {
+          preferSharedInbox: true,
+          excludeBaseUris: [new URL(this.session.context.origin)],
+          fanout: "skip",
+        },
+      );
+    }
+    await this.session.context.sendActivity(
+      this.session.bot,
+      "followers",
+      del,
+      {
+        preferSharedInbox: true,
+        excludeBaseUris: [new URL(this.session.context.origin)],
+      },
+    );
+  }
+
+  async #getQuoteActor(quoteId: URL): Promise<Actor> {
+    const documentLoader = await this.session.context.getDocumentLoader(
+      this.session.bot,
+    );
+    const object = await this.session.context.lookupObject(quoteId, {
+      documentLoader,
+    });
+    if (!isMessageObject(object)) {
+      throw new TypeError("The quote message does not exist.");
+    }
+    return (await createMessage(object, this.session, {})).actor;
+  }
 }
 
 // @ts-ignore: The `xss` module has `getDefaultWhiteList` function.
@@ -647,12 +740,17 @@ export async function createMessage<T extends MessageClass, TContextData>(
     documentLoader,
     suppressError: true,
   };
-  const actor = raw.attributionId?.href === session.actorId?.href
+  const rawActor = raw.attributionId?.href === session.actorId?.href
     ? await session.getActor()
-    : await raw.getAttribution(options);
-  if (actor == null) {
+    : raw.attributionId == null
+    ? null
+    : cachedObjects[raw.attributionId.href] == null
+    ? await raw.getAttribution(options)
+    : cachedObjects[raw.attributionId.href];
+  if (!isActor(rawActor)) {
     throw new TypeError("The raw.attributionId is required.");
   }
+  const actor = rawActor;
   const content = raw.content.toString();
   const text = textXss.process(content);
   const html = htmlXss.process(content);

--- a/packages/botkit/src/message-impl.ts
+++ b/packages/botkit/src/message-impl.ts
@@ -616,6 +616,9 @@ export class AuthorizedMessageImpl<T extends MessageClass, TContextData>
     quote: Message<MessageClass, TContextData> | URL,
   ): Promise<void> {
     const quoteId = quote instanceof URL ? quote : quote.id;
+    if (quoteId == null) {
+      throw new TypeError("The quote message ID is missing.");
+    }
     const authorization = await this.session.bot.repository
       .findQuoteAuthorization(quoteId);
     if (authorization == null || authorization.id == null) {

--- a/packages/botkit/src/message-impl.ts
+++ b/packages/botkit/src/message-impl.ts
@@ -811,13 +811,15 @@ export async function createMessage<T extends MessageClass, TContextData>(
     }
   }
   if (quoteTarget == null) {
-    let quoteUrl: URL | null = null;
-    for (const quoteLink of quoteLinks) {
-      if (quoteLink.href == null) continue;
-      quoteUrl = quoteLink.href;
-      break;
+    let quoteUrl = raw.quoteId;
+    if (quoteUrl == null) {
+      for (const quoteLink of quoteLinks) {
+        if (quoteLink.href == null) continue;
+        quoteUrl = quoteLink.href;
+        break;
+      }
     }
-    if (quoteUrl == null) quoteUrl = raw.quoteId ?? raw.quoteUrl;
+    if (quoteUrl == null) quoteUrl = raw.quoteUrl;
     let qt: Object | null = null;
     const parsed = parseLocalUri(
       session.context,

--- a/packages/botkit/src/message-impl.ts
+++ b/packages/botkit/src/message-impl.ts
@@ -817,7 +817,7 @@ export async function createMessage<T extends MessageClass, TContextData>(
       quoteUrl = quoteLink.href;
       break;
     }
-    if (quoteUrl == null) quoteUrl = raw.quoteUrl;
+    if (quoteUrl == null) quoteUrl = raw.quoteId ?? raw.quoteUrl;
     let qt: Object | null = null;
     const parsed = parseLocalUri(
       session.context,

--- a/packages/botkit/src/message.ts
+++ b/packages/botkit/src/message.ts
@@ -30,6 +30,7 @@ import type {
   SessionPublishOptions,
   SessionPublishOptionsWithClass,
 } from "./session.ts";
+import type { QuotePolicyOption } from "./quote.ts";
 import type { Text } from "./text.ts";
 export {
   Article,
@@ -227,8 +228,12 @@ export interface AuthorizedMessage<T extends MessageClass, TContextData>
   /**
    * Updates the message with new content.
    * @param text The new content of the message.
+   * @param options The options for updating the message.
    */
-  update(text: Text<"block", TContextData>): Promise<void>;
+  update(
+    text: Text<"block", TContextData>,
+    options?: AuthorizedMessageUpdateOptions,
+  ): Promise<void>;
 
   /**
    * Deletes the message, if possible.
@@ -236,6 +241,27 @@ export interface AuthorizedMessage<T extends MessageClass, TContextData>
    * If the message is already deleted, it will be a no-op.
    */
   delete(): Promise<void>;
+
+  /**
+   * Revokes the authorization stamp issued to a quote of this message.
+   * @param quote The quoted message or its URI.
+   * @throws {TypeError} The quote authorization does not exist.
+   * @since 0.5.0
+   */
+  unauthorizeQuote(
+    quote: Message<MessageClass, TContextData> | URL,
+  ): Promise<void>;
+}
+
+/**
+ * Options for updating an authorized message.
+ * @since 0.5.0
+ */
+export interface AuthorizedMessageUpdateOptions {
+  /**
+   * Who can quote the updated message.
+   */
+  readonly quotePolicy?: QuotePolicyOption;
 }
 
 /**

--- a/packages/botkit/src/mod.ts
+++ b/packages/botkit/src/mod.ts
@@ -74,6 +74,13 @@ export type {
   SharedMessage,
 } from "./message.ts";
 export type { Poll, Vote } from "./poll.ts";
+export type {
+  QuoteAcceptance,
+  QuotePolicy,
+  QuotePolicyOption,
+  QuoteRequest,
+} from "./quote.ts";
+export { normalizeQuotePolicy } from "./quote.ts";
 export {
   type AuthorizedLike,
   type AuthorizedReaction,

--- a/packages/botkit/src/mod.ts
+++ b/packages/botkit/src/mod.ts
@@ -66,6 +66,7 @@ export {
 export type {
   Actor,
   AuthorizedMessage,
+  AuthorizedMessageUpdateOptions,
   AuthorizedSharedMessage,
   Message,
   MessageClass,

--- a/packages/botkit/src/quote-impl.ts
+++ b/packages/botkit/src/quote-impl.ts
@@ -63,13 +63,15 @@ export class QuoteRequestImpl<TContextData>
     this.#state = "pending";
   }
 
-  async accept(): Promise<void> {
+  async accept(signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
     if (this.#state !== "pending") {
       throw new TypeError("The quote request is not pending.");
     }
     const existing = await this.session.bot.repository.findQuoteAuthorization(
       this.quote.id,
     );
+    signal?.throwIfAborted();
     const authorization = existing ?? await this.#createAuthorization();
     await this.session.context.sendActivity(
       this.session.bot,
@@ -86,10 +88,12 @@ export class QuoteRequestImpl<TContextData>
     this.#state = "accepted";
   }
 
-  async reject(): Promise<void> {
+  async reject(signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
     if (this.#state !== "pending") {
       throw new TypeError("The quote request is not pending.");
     }
+    signal?.throwIfAborted();
     await this.session.context.sendActivity(
       this.session.bot,
       this.actor,

--- a/packages/botkit/src/quote-impl.ts
+++ b/packages/botkit/src/quote-impl.ts
@@ -1,0 +1,123 @@
+// BotKit by Fedify: A framework for creating ActivityPub bots
+// Copyright (C) 2025–2026 Hong Minhee <https://hongminhee.org/>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import {
+  Accept,
+  type Actor,
+  QuoteAuthorization,
+  type QuoteRequest as RawQuoteRequest,
+  Reject,
+} from "@fedify/vocab";
+import { v7 as uuidv7 } from "uuid";
+import type { AuthorizedMessage, Message, MessageClass } from "./message.ts";
+import type { QuoteRequest } from "./quote.ts";
+import type { Uuid } from "./repository.ts";
+import type { SessionImpl } from "./session-impl.ts";
+
+export class QuoteRequestImpl<TContextData>
+  implements QuoteRequest<TContextData> {
+  readonly session: SessionImpl<TContextData>;
+  readonly id: URL;
+  readonly raw: RawQuoteRequest;
+  readonly actor: Actor;
+  readonly quote: Message<MessageClass, TContextData>;
+  readonly target: AuthorizedMessage<MessageClass, TContextData>;
+  #state: "pending" | "accepted" | "rejected";
+
+  get state(): "pending" | "accepted" | "rejected" {
+    return this.#state;
+  }
+
+  constructor(
+    session: SessionImpl<TContextData>,
+    raw: RawQuoteRequest,
+    actor: Actor,
+    quote: Message<MessageClass, TContextData>,
+    target: AuthorizedMessage<MessageClass, TContextData>,
+  ) {
+    if (raw.id == null) {
+      throw new TypeError("The quote request ID is missing.");
+    } else if (actor.id == null) {
+      throw new TypeError("The quote requester ID is missing.");
+    } else if (quote.id == null) {
+      throw new TypeError("The quote message ID is missing.");
+    }
+    this.session = session;
+    this.id = raw.id;
+    this.raw = raw;
+    this.actor = actor;
+    this.quote = quote;
+    this.target = target;
+    this.#state = "pending";
+  }
+
+  async accept(): Promise<void> {
+    if (this.#state !== "pending") {
+      throw new TypeError("The quote request is not pending.");
+    }
+    const existing = await this.session.bot.repository.findQuoteAuthorization(
+      this.quote.id,
+    );
+    const authorization = existing ?? await this.#createAuthorization();
+    await this.session.context.sendActivity(
+      this.session.bot,
+      this.actor,
+      new Accept({
+        id: new URL(`/#accept/${this.id.href}`, this.session.actorId),
+        actor: this.session.actorId,
+        to: this.actor.id,
+        object: this.raw,
+        result: authorization.id,
+      }),
+      { excludeBaseUris: [new URL(this.session.context.origin)] },
+    );
+    this.#state = "accepted";
+  }
+
+  async reject(): Promise<void> {
+    if (this.#state !== "pending") {
+      throw new TypeError("The quote request is not pending.");
+    }
+    await this.session.context.sendActivity(
+      this.session.bot,
+      this.actor,
+      new Reject({
+        id: new URL(`/#reject/${this.id.href}`, this.session.actorId),
+        actor: this.session.actorId,
+        to: this.actor.id,
+        object: this.raw,
+      }),
+      { excludeBaseUris: [new URL(this.session.context.origin)] },
+    );
+    this.#state = "rejected";
+  }
+
+  async #createAuthorization(): Promise<QuoteAuthorization> {
+    const id = uuidv7() as Uuid;
+    const authorization = new QuoteAuthorization({
+      id: this.session.context.getObjectUri(QuoteAuthorization, {
+        identifier: this.session.bot.identifier,
+        id,
+      }),
+      attribution: this.session.actorId,
+      interactingObject: this.quote.id,
+      interactionTarget: this.target.id,
+    });
+    await this.session.bot.repository.addQuoteAuthorization(id, authorization);
+    return await this.session.bot.repository.findQuoteAuthorization(
+      this.quote.id,
+    ) ?? authorization;
+  }
+}

--- a/packages/botkit/src/quote-impl.ts
+++ b/packages/botkit/src/quote-impl.ts
@@ -73,6 +73,14 @@ export class QuoteRequestImpl<TContextData>
     const existing = await this.session.bot.repository.findQuoteAuthorization(
       this.quote.id,
     );
+    if (
+      existing != null &&
+      existing.interactionTargetId?.href !== this.target.id.href
+    ) {
+      throw new TypeError(
+        "The quote authorization does not belong to this message.",
+      );
+    }
     signal?.throwIfAborted();
     const authorization = existing ?? await this.#createAuthorization();
     await this.session.context.sendActivity(

--- a/packages/botkit/src/quote-impl.ts
+++ b/packages/botkit/src/quote-impl.ts
@@ -53,6 +53,8 @@ export class QuoteRequestImpl<TContextData>
       throw new TypeError("The quote requester ID is missing.");
     } else if (quote.id == null) {
       throw new TypeError("The quote message ID is missing.");
+    } else if (target.id == null) {
+      throw new TypeError("The target message ID is missing.");
     }
     this.session = session;
     this.id = raw.id;

--- a/packages/botkit/src/quote-impl.ts
+++ b/packages/botkit/src/quote-impl.ts
@@ -83,6 +83,11 @@ export class QuoteRequestImpl<TContextData>
     }
     signal?.throwIfAborted();
     const authorization = existing ?? await this.#createAuthorization();
+    if (authorization.interactionTargetId?.href !== this.target.id.href) {
+      throw new TypeError(
+        "The quote authorization does not belong to this message.",
+      );
+    }
     await this.session.context.sendActivity(
       this.session.bot,
       this.actor,

--- a/packages/botkit/src/quote.test.ts
+++ b/packages/botkit/src/quote.test.ts
@@ -1,0 +1,77 @@
+// BotKit by Fedify: A framework for creating ActivityPub bots
+// Copyright (C) 2025–2026 Hong Minhee <https://hongminhee.org/>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { PUBLIC_COLLECTION } from "@fedify/vocab";
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { normalizeQuotePolicy, serializeQuotePolicy } from "./quote.ts";
+
+describe("normalizeQuotePolicy()", () => {
+  test("normalizes string policies", () => {
+    assert.deepStrictEqual(normalizeQuotePolicy(), { automatic: "public" });
+    assert.deepStrictEqual(normalizeQuotePolicy("public"), {
+      automatic: "public",
+    });
+    assert.deepStrictEqual(normalizeQuotePolicy("followers"), {
+      automatic: "followers",
+    });
+    assert.deepStrictEqual(normalizeQuotePolicy("nobody"), {
+      automatic: "nobody",
+    });
+    assert.deepStrictEqual(normalizeQuotePolicy("manual"), {
+      manual: "public",
+    });
+  });
+
+  test("preserves object policies", () => {
+    assert.deepStrictEqual(
+      normalizeQuotePolicy({ automatic: "followers", manual: "public" }),
+      { automatic: "followers", manual: "public" },
+    );
+  });
+});
+
+describe("serializeQuotePolicy()", () => {
+  const actor = new URL("https://example.com/ap/actor/bot");
+  const followers = new URL("https://example.com/ap/actor/bot/followers");
+
+  test("serializes public automatic approval", () => {
+    const rule = serializeQuotePolicy("public", actor, followers).canQuote;
+    assert.deepStrictEqual(rule?.automaticApprovals, [PUBLIC_COLLECTION]);
+    assert.deepStrictEqual(rule?.manualApprovals, []);
+  });
+
+  test("serializes followers automatic approval", () => {
+    const rule = serializeQuotePolicy("followers", actor, followers).canQuote;
+    assert.deepStrictEqual(rule?.automaticApprovals, [actor, followers]);
+    assert.deepStrictEqual(rule?.manualApprovals, []);
+  });
+
+  test("serializes nobody automatic approval as actor-only", () => {
+    const rule = serializeQuotePolicy("nobody", actor, followers).canQuote;
+    assert.deepStrictEqual(rule?.automaticApprovals, [actor]);
+    assert.deepStrictEqual(rule?.manualApprovals, []);
+  });
+
+  test("serializes manual followers approval", () => {
+    const rule = serializeQuotePolicy(
+      { manual: "followers" },
+      actor,
+      followers,
+    ).canQuote;
+    assert.deepStrictEqual(rule?.automaticApprovals, []);
+    assert.deepStrictEqual(rule?.manualApprovals, [followers]);
+  });
+});

--- a/packages/botkit/src/quote.ts
+++ b/packages/botkit/src/quote.ts
@@ -91,15 +91,17 @@ export interface QuoteRequest<TContextData> {
 
   /**
    * Accepts the quote request.
+   * @param signal An abort signal.
    * @throws {TypeError} The quote request is not pending.
    */
-  accept(): Promise<void>;
+  accept(signal?: AbortSignal): Promise<void>;
 
   /**
    * Rejects the quote request.
+   * @param signal An abort signal.
    * @throws {TypeError} The quote request is not pending.
    */
-  reject(): Promise<void>;
+  reject(signal?: AbortSignal): Promise<void>;
 }
 
 /**
@@ -116,6 +118,15 @@ export function normalizeQuotePolicy(
   return policy;
 }
 
+/**
+ * Serializes a quote policy option into an interaction policy for outgoing
+ * messages.
+ * @param policy The quote policy option to serialize.
+ * @param actorUri The URI of the actor publishing the message.
+ * @param followersUri The URI of the actor's followers collection.
+ * @returns The serialized interaction policy.
+ * @since 0.5.0
+ */
 export function serializeQuotePolicy(
   policy: QuotePolicyOption | undefined,
   actorUri: URL,

--- a/packages/botkit/src/quote.ts
+++ b/packages/botkit/src/quote.ts
@@ -1,0 +1,159 @@
+// BotKit by Fedify: A framework for creating ActivityPub bots
+// Copyright (C) 2025–2026 Hong Minhee <https://hongminhee.org/>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import {
+  type Actor,
+  InteractionPolicy,
+  InteractionRule,
+  PUBLIC_COLLECTION,
+  type QuoteRequest as RawQuoteRequest,
+} from "@fedify/vocab";
+import type { AuthorizedMessage, Message, MessageClass } from "./message.ts";
+
+/**
+ * The audience whose quote requests can be approved.
+ * @since 0.5.0
+ */
+export type QuoteAcceptance = "public" | "followers" | "nobody";
+
+/**
+ * A quote policy for messages published by the bot.
+ *
+ * The `automatic` axis is accepted immediately.  The `manual` axis is exposed
+ * to {@link QuoteRequestEventHandler} as a pending request.
+ * @since 0.5.0
+ */
+export interface QuotePolicy {
+  /**
+   * The audience whose quote requests are accepted automatically.
+   */
+  readonly automatic?: QuoteAcceptance;
+
+  /**
+   * The audience whose quote requests wait for manual approval.
+   */
+  readonly manual?: QuoteAcceptance;
+}
+
+/**
+ * A shorthand or full quote policy.
+ * @since 0.5.0
+ */
+export type QuotePolicyOption = QuoteAcceptance | "manual" | QuotePolicy;
+
+/**
+ * A quote request to the bot.
+ * @typeParam TContextData The type of the context data.
+ * @since 0.5.0
+ */
+export interface QuoteRequest<TContextData> {
+  /**
+   * The URI of the quote request.
+   */
+  readonly id: URL;
+
+  /**
+   * The raw quote request object.
+   */
+  readonly raw: RawQuoteRequest;
+
+  /**
+   * The actor requesting quote authorization.
+   */
+  readonly actor: Actor;
+
+  /**
+   * The message that quotes the bot's message.
+   */
+  readonly quote: Message<MessageClass, TContextData>;
+
+  /**
+   * The bot's message being quoted.
+   */
+  readonly target: AuthorizedMessage<MessageClass, TContextData>;
+
+  /**
+   * The state of the quote request.
+   */
+  readonly state: "pending" | "accepted" | "rejected";
+
+  /**
+   * Accepts the quote request.
+   * @throws {TypeError} The quote request is not pending.
+   */
+  accept(): Promise<void>;
+
+  /**
+   * Rejects the quote request.
+   * @throws {TypeError} The quote request is not pending.
+   */
+  reject(): Promise<void>;
+}
+
+/**
+ * Normalizes a quote policy option into the two-axis form.
+ * @param policy The quote policy option to normalize.
+ * @returns The normalized quote policy.
+ * @since 0.5.0
+ */
+export function normalizeQuotePolicy(
+  policy: QuotePolicyOption = "public",
+): QuotePolicy {
+  if (policy === "manual") return { manual: "public" };
+  if (typeof policy === "string") return { automatic: policy };
+  return policy;
+}
+
+export function serializeQuotePolicy(
+  policy: QuotePolicyOption | undefined,
+  actorUri: URL,
+  followersUri: URL,
+): InteractionPolicy {
+  const normalized = normalizeQuotePolicy(policy);
+  return new InteractionPolicy({
+    canQuote: new InteractionRule({
+      automaticApprovals: serializeQuoteAcceptance(
+        normalized.automatic,
+        actorUri,
+        followersUri,
+        true,
+      ),
+      manualApprovals: serializeQuoteAcceptance(
+        normalized.manual,
+        actorUri,
+        followersUri,
+        false,
+      ),
+    }),
+  });
+}
+
+function serializeQuoteAcceptance(
+  acceptance: QuoteAcceptance | undefined,
+  actorUri: URL,
+  followersUri: URL,
+  automatic: boolean,
+): URL[] {
+  switch (acceptance) {
+    case "public":
+      return [PUBLIC_COLLECTION];
+    case "followers":
+      return automatic ? [actorUri, followersUri] : [followersUri];
+    case "nobody":
+      return automatic ? [actorUri] : [];
+    default:
+      return [];
+  }
+}

--- a/packages/botkit/src/repository.test.ts
+++ b/packages/botkit/src/repository.test.ts
@@ -212,6 +212,36 @@ test("KvRepository serializes concurrent quote authorization inserts", async () 
   assert.deepStrictEqual(indexed?.id?.href, stored[0].id?.href);
 });
 
+test("KvRepository replaces stale quote authorization indexes", async () => {
+  const kv = new MemoryKvStore();
+  const repository = new KvRepository(kv);
+  const staleId = "01942976-3400-7f34-872e-2cbf0f9eeac4" as Uuid;
+  const id = "01942976-3400-7f34-872e-2cbf0f9eeac5" as Uuid;
+  const interactingObject = new URL("https://remote.example/notes/quote");
+  const authorization = new QuoteAuthorization({
+    id: new URL(
+      `https://example.com/ap/actor/bot/quote-authorization/${id}`,
+    ),
+    attribution: new URL("https://example.com/ap/actor/bot"),
+    interactingObject,
+    interactionTarget: new URL("https://example.com/ap/note/1"),
+  });
+  const indexKey = scopedKvKey(
+    "quoteAuthorizationsByInteractingObject",
+    interactingObject.href,
+  );
+  await kv.set(indexKey, staleId);
+
+  await repository.addQuoteAuthorization("bot", id, authorization);
+
+  assert.deepStrictEqual(await kv.get(indexKey), id);
+  assert.deepStrictEqual(
+    (await repository.findQuoteAuthorization("bot", interactingObject))?.id
+      ?.href,
+    authorization.id?.href,
+  );
+});
+
 test("KvRepository removes quote authorization indexes before parsing", async () => {
   const kv = new MemoryKvStore();
   const repository = new KvRepository(kv);

--- a/packages/botkit/src/repository.test.ts
+++ b/packages/botkit/src/repository.test.ts
@@ -21,7 +21,14 @@ import {
   MemoryKvStore,
 } from "@fedify/fedify/federation";
 import { exportJwk, importJwk } from "@fedify/fedify/sig";
-import { Create, Follow, Note, Person, PUBLIC_COLLECTION } from "@fedify/vocab";
+import {
+  Create,
+  Follow,
+  Note,
+  Person,
+  PUBLIC_COLLECTION,
+  QuoteAuthorization,
+} from "@fedify/vocab";
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import {
@@ -49,6 +56,121 @@ const factories: Record<string, () => Repository> = {
   MemoryRepository: createMemoryRepository,
   MemoryCachedRepository: createMemoryCachedRepository,
 };
+
+for (const [name, factory] of Object.entries(factories)) {
+  test(`${name} stores quote authorizations`, async () => {
+    const repository = factory();
+    const id = "01942976-3400-7f34-872e-2cbf0f9eeac4" as Uuid;
+    const interactingObject = new URL("https://remote.example/notes/1");
+    const authorization = new QuoteAuthorization({
+      id: new URL(
+        `https://example.com/ap/actor/bot/quote-authorization/${id}`,
+      ),
+      attribution: new URL("https://example.com/ap/actor/bot"),
+      interactingObject,
+      interactionTarget: new URL("https://example.com/ap/note/1"),
+    });
+
+    await repository.addQuoteAuthorization("bot", id, authorization);
+
+    assert.deepStrictEqual(
+      (await repository.getQuoteAuthorization("bot", id))?.id?.href,
+      authorization.id?.href,
+    );
+    assert.deepStrictEqual(
+      (await repository.findQuoteAuthorization("bot", interactingObject))?.id
+        ?.href,
+      authorization.id?.href,
+    );
+    assert.deepStrictEqual(
+      (await repository.removeQuoteAuthorization("bot", id))?.id?.href,
+      authorization.id?.href,
+    );
+    assert.deepStrictEqual(
+      await repository.getQuoteAuthorization("bot", id),
+      undefined,
+    );
+    assert.deepStrictEqual(
+      await repository.findQuoteAuthorization("bot", interactingObject),
+      undefined,
+    );
+  });
+
+  test(`${name} keeps the first quote authorization for a quote`, async () => {
+    const repository = factory();
+    const firstId = "01942976-3400-7f34-872e-2cbf0f9eeac4" as Uuid;
+    const secondId = "01942976-3400-7f34-872e-2cbf0f9eeac5" as Uuid;
+    const interactingObject = new URL("https://remote.example/notes/1");
+    const target = new URL("https://example.com/ap/note/1");
+    const first = new QuoteAuthorization({
+      id: new URL(
+        `https://example.com/ap/actor/bot/quote-authorization/${firstId}`,
+      ),
+      attribution: new URL("https://example.com/ap/actor/bot"),
+      interactingObject,
+      interactionTarget: target,
+    });
+    const second = new QuoteAuthorization({
+      id: new URL(
+        `https://example.com/ap/actor/bot/quote-authorization/${secondId}`,
+      ),
+      attribution: new URL("https://example.com/ap/actor/bot"),
+      interactingObject,
+      interactionTarget: target,
+    });
+
+    await repository.addQuoteAuthorization("bot", firstId, first);
+    await repository.addQuoteAuthorization("bot", secondId, second);
+
+    assert.deepStrictEqual(
+      (await repository.findQuoteAuthorization("bot", interactingObject))?.id
+        ?.href,
+      first.id?.href,
+    );
+    assert.deepStrictEqual(
+      await repository.getQuoteAuthorization("bot", secondId),
+      undefined,
+    );
+  });
+}
+
+test("MemoryCachedRepository keeps duplicate quote authorizations out of cache", async () => {
+  const underlying = createKvRepository();
+  const repository = new MemoryCachedRepository(underlying);
+  const firstId = "01942976-3400-7f34-872e-2cbf0f9eeac4" as Uuid;
+  const secondId = "01942976-3400-7f34-872e-2cbf0f9eeac5" as Uuid;
+  const interactingObject = new URL("https://remote.example/notes/1");
+  const target = new URL("https://example.com/ap/note/1");
+  const first = new QuoteAuthorization({
+    id: new URL(
+      `https://example.com/ap/actor/bot/quote-authorization/${firstId}`,
+    ),
+    attribution: new URL("https://example.com/ap/actor/bot"),
+    interactingObject,
+    interactionTarget: target,
+  });
+  const second = new QuoteAuthorization({
+    id: new URL(
+      `https://example.com/ap/actor/bot/quote-authorization/${secondId}`,
+    ),
+    attribution: new URL("https://example.com/ap/actor/bot"),
+    interactingObject,
+    interactionTarget: target,
+  });
+
+  await underlying.addQuoteAuthorization("bot", firstId, first);
+  await repository.addQuoteAuthorization("bot", secondId, second);
+
+  assert.deepStrictEqual(
+    (await repository.findQuoteAuthorization("bot", interactingObject))?.id
+      ?.href,
+    first.id?.href,
+  );
+  assert.deepStrictEqual(
+    await repository.getQuoteAuthorization("bot", secondId),
+    undefined,
+  );
+});
 
 function scopedKvKey(...rest: readonly string[]): KvKey {
   return ["_botkit", "bots", "bot", ...rest];

--- a/packages/botkit/src/repository.test.ts
+++ b/packages/botkit/src/repository.test.ts
@@ -212,6 +212,34 @@ test("KvRepository serializes concurrent quote authorization inserts", async () 
   assert.deepStrictEqual(indexed?.id?.href, stored[0].id?.href);
 });
 
+test("KvRepository removes quote authorization indexes before parsing", async () => {
+  const kv = new MemoryKvStore();
+  const repository = new KvRepository(kv);
+  const id = "01942976-3400-7f34-872e-2cbf0f9eeac4" as Uuid;
+  const interactingObject = new URL("https://remote.example/notes/quote");
+  const authorizationKey = scopedKvKey("quoteAuthorizations", id);
+  const indexKey = scopedKvKey(
+    "quoteAuthorizationsByInteractingObject",
+    interactingObject.href,
+  );
+  await kv.set(authorizationKey, {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    type: "QuoteAuthorization",
+    interactingObject: interactingObject.href,
+  });
+  await kv.set(indexKey, id);
+
+  const removed = await repository.removeQuoteAuthorization("bot", id);
+
+  assert.ok(removed?.interactingObjectId == null);
+  assert.deepStrictEqual(await kv.get(authorizationKey), undefined);
+  assert.deepStrictEqual(await kv.get(indexKey), undefined);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorization("bot", interactingObject),
+    undefined,
+  );
+});
+
 function scopedKvKey(...rest: readonly string[]): KvKey {
   return ["_botkit", "bots", "bot", ...rest];
 }

--- a/packages/botkit/src/repository.test.ts
+++ b/packages/botkit/src/repository.test.ts
@@ -172,6 +172,46 @@ test("MemoryCachedRepository keeps duplicate quote authorizations out of cache",
   );
 });
 
+test("KvRepository serializes concurrent quote authorization inserts", async () => {
+  const repository = new KvRepository(new RacingQuoteAuthorizationKvStore());
+  const firstId = "01942976-3400-7f34-872e-2cbf0f9eeac4" as Uuid;
+  const secondId = "01942976-3400-7f34-872e-2cbf0f9eeac5" as Uuid;
+  const interactingObject = new URL("https://remote.example/notes/1");
+  const target = new URL("https://example.com/ap/note/1");
+  const first = new QuoteAuthorization({
+    id: new URL(
+      `https://example.com/ap/actor/bot/quote-authorization/${firstId}`,
+    ),
+    attribution: new URL("https://example.com/ap/actor/bot"),
+    interactingObject,
+    interactionTarget: target,
+  });
+  const second = new QuoteAuthorization({
+    id: new URL(
+      `https://example.com/ap/actor/bot/quote-authorization/${secondId}`,
+    ),
+    attribution: new URL("https://example.com/ap/actor/bot"),
+    interactingObject,
+    interactionTarget: target,
+  });
+
+  await Promise.all([
+    repository.addQuoteAuthorization("bot", firstId, first),
+    repository.addQuoteAuthorization("bot", secondId, second),
+  ]);
+
+  const indexed = await repository.findQuoteAuthorization(
+    "bot",
+    interactingObject,
+  );
+  const stored = [
+    await repository.getQuoteAuthorization("bot", firstId),
+    await repository.getQuoteAuthorization("bot", secondId),
+  ].filter((authorization) => authorization != null);
+  assert.deepStrictEqual(stored.length, 1);
+  assert.deepStrictEqual(indexed?.id?.href, stored[0].id?.href);
+});
+
 function scopedKvKey(...rest: readonly string[]): KvKey {
   return ["_botkit", "bots", "bot", ...rest];
 }
@@ -224,6 +264,29 @@ class RecordingListMemoryKvStore extends MemoryKvStore {
   override list(prefix?: KvKey): AsyncIterable<KvStoreListEntry> {
     this.listCalls++;
     return super.list(prefix);
+  }
+}
+
+class RacingQuoteAuthorizationKvStore extends MemoryKvStore {
+  #indexGets = 0;
+  #releaseIndexGets: (() => void) | undefined;
+  #indexGetBarrier = new Promise<void>((resolve) => {
+    this.#releaseIndexGets = resolve;
+  });
+
+  override async get<T = unknown>(key: KvKey): Promise<T | undefined> {
+    if (
+      key.includes("quoteAuthorizationsByInteractingObject") &&
+      !key.includes("lock")
+    ) {
+      const lock = await super.get([...key, "lock"]);
+      if (lock == null && this.#indexGets < 2) {
+        this.#indexGets++;
+        if (this.#indexGets === 2) this.#releaseIndexGets?.();
+        await this.#indexGetBarrier;
+      }
+    }
+    return await super.get<T>(key);
   }
 }
 

--- a/packages/botkit/src/repository.ts
+++ b/packages/botkit/src/repository.ts
@@ -835,6 +835,18 @@ export class KvRepository implements Repository {
     );
   }
 
+  #quoteAuthorizationLockKey(
+    identifier: string,
+    interactingObject: URL,
+  ): KvKey {
+    return this.#key(
+      identifier,
+      "quoteAuthorizationsByInteractingObject",
+      interactingObject.href,
+      "lock",
+    );
+  }
+
   /**
    * Migrates data stored by BotKit 0.4 or earlier, which was not scoped by
    * bot actor identifiers, so that it belongs to the given identifier.
@@ -1571,17 +1583,22 @@ export class KvRepository implements Repository {
         "The quote authorization interacting object is missing.",
       );
     }
-    const existing = await this.kv.get<Uuid>(
-      this.#quoteAuthorizationIndexKey(identifier, interactingObject),
-    );
-    if (existing != null) return;
-    await this.kv.set(
-      this.#key(identifier, "quoteAuthorizations", id),
-      await authorization.toJsonLd({ format: "compact" }),
-    );
-    await this.kv.set(
-      this.#quoteAuthorizationIndexKey(identifier, interactingObject),
-      id,
+    await this.#withKvLock(
+      this.#quoteAuthorizationLockKey(identifier, interactingObject),
+      async () => {
+        const existing = await this.kv.get<Uuid>(
+          this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+        );
+        if (existing != null) return;
+        await this.kv.set(
+          this.#key(identifier, "quoteAuthorizations", id),
+          await authorization.toJsonLd({ format: "compact" }),
+        );
+        await this.kv.set(
+          this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+          id,
+        );
+      },
     );
   }
 
@@ -1623,13 +1640,25 @@ export class KvRepository implements Repository {
   ): Promise<QuoteAuthorization | undefined> {
     const authorization = await this.getQuoteAuthorization(identifier, id);
     if (authorization == null) return undefined;
-    await this.kv.delete(this.#key(identifier, "quoteAuthorizations", id));
     const interactingObject = authorization.interactingObjectId;
-    if (interactingObject != null) {
-      await this.kv.delete(
-        this.#quoteAuthorizationIndexKey(identifier, interactingObject),
-      );
+    if (interactingObject == null) {
+      await this.kv.delete(this.#key(identifier, "quoteAuthorizations", id));
+      return authorization;
     }
+    await this.#withKvLock(
+      this.#quoteAuthorizationLockKey(identifier, interactingObject),
+      async () => {
+        await this.kv.delete(this.#key(identifier, "quoteAuthorizations", id));
+        const indexedId = await this.kv.get<Uuid>(
+          this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+        );
+        if (indexedId === id) {
+          await this.kv.delete(
+            this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+          );
+        }
+      },
+    );
     return authorization;
   }
 

--- a/packages/botkit/src/repository.ts
+++ b/packages/botkit/src/repository.ts
@@ -2153,9 +2153,14 @@ export class MemoryRepository implements Repository {
     data.quoteAuthorizations.delete(id);
     const interactingObject = authorization?.interactingObjectId;
     if (interactingObject != null) {
-      data.quoteAuthorizationsByInteractingObject.delete(
+      const indexedId = data.quoteAuthorizationsByInteractingObject.get(
         interactingObject.href,
       );
+      if (indexedId === id) {
+        data.quoteAuthorizationsByInteractingObject.delete(
+          interactingObject.href,
+        );
+      }
     }
     return Promise.resolve(authorization);
   }

--- a/packages/botkit/src/repository.ts
+++ b/packages/botkit/src/repository.ts
@@ -1603,7 +1603,16 @@ export class KvRepository implements Repository {
         const existing = await this.kv.get<Uuid>(
           this.#quoteAuthorizationIndexKey(identifier, interactingObject),
         );
-        if (existing != null) return;
+        if (existing != null) {
+          const authorization = await this.getQuoteAuthorization(
+            identifier,
+            existing,
+          );
+          if (authorization != null) return;
+          await this.kv.delete(
+            this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+          );
+        }
         await this.kv.set(
           this.#key(identifier, "quoteAuthorizations", id),
           await authorization.toJsonLd({ format: "compact" }),

--- a/packages/botkit/src/repository.ts
+++ b/packages/botkit/src/repository.ts
@@ -23,6 +23,7 @@ import {
   Follow,
   isActor,
   Object,
+  QuoteAuthorization,
 } from "@fedify/vocab";
 import { getLogger } from "@logtape/logtape";
 export type { KvKey, KvStore } from "@fedify/fedify/federation";
@@ -293,6 +294,58 @@ export interface Repository {
    * @since 0.5.0
    */
   findFollowedBots(followeeId: URL): AsyncIterable<string>;
+
+  /**
+   * Adds a quote authorization stamp to the repository.
+   * @param identifier The identifier of the bot actor that issued the stamp.
+   * @param id The UUID of the quote authorization.
+   * @param authorization The quote authorization stamp to add.
+   * @since 0.5.0
+   */
+  addQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+    authorization: QuoteAuthorization,
+  ): Promise<void>;
+
+  /**
+   * Gets a quote authorization stamp from the repository.
+   * @param identifier The identifier of the bot actor that issued the stamp.
+   * @param id The UUID of the quote authorization.
+   * @returns The quote authorization stamp, or `undefined` if it does not
+   *          exist.
+   * @since 0.5.0
+   */
+  getQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined>;
+
+  /**
+   * Finds a quote authorization stamp by the quote post it authorizes.
+   * @param identifier The identifier of the bot actor that issued the stamp.
+   * @param interactingObject The URI of the quote post.
+   * @returns The quote authorization stamp, or `undefined` if it does not
+   *          exist.
+   * @since 0.5.0
+   */
+  findQuoteAuthorization(
+    identifier: string,
+    interactingObject: URL,
+  ): Promise<QuoteAuthorization | undefined>;
+
+  /**
+   * Removes a quote authorization stamp from the repository.
+   * @param identifier The identifier of the bot actor that issued the stamp.
+   * @param id The UUID of the quote authorization.
+   * @returns The removed quote authorization stamp, or `undefined` if it does
+   *          not exist.
+   * @since 0.5.0
+   */
+  removeQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined>;
 
   /**
    * Records a vote in a poll.  If the same voter had already voted for the
@@ -616,6 +669,60 @@ export class ActorScopedRepository {
   countVotes(messageId: Uuid): Promise<Readonly<Record<string, number>>> {
     return this.repository.countVotes(this.identifier, messageId);
   }
+
+  /**
+   * Adds a quote authorization stamp to the repository.
+   * @param id The UUID of the quote authorization.
+   * @param authorization The quote authorization stamp to add.
+   * @since 0.5.0
+   */
+  addQuoteAuthorization(
+    id: Uuid,
+    authorization: QuoteAuthorization,
+  ): Promise<void> {
+    return this.repository.addQuoteAuthorization(
+      this.identifier,
+      id,
+      authorization,
+    );
+  }
+
+  /**
+   * Gets a quote authorization stamp from the repository.
+   * @param id The UUID of the quote authorization.
+   * @returns The quote authorization stamp, or `undefined`.
+   * @since 0.5.0
+   */
+  getQuoteAuthorization(id: Uuid): Promise<QuoteAuthorization | undefined> {
+    return this.repository.getQuoteAuthorization(this.identifier, id);
+  }
+
+  /**
+   * Finds a quote authorization stamp by the quote post it authorizes.
+   * @param interactingObject The URI of the quote post.
+   * @returns The quote authorization stamp, or `undefined`.
+   * @since 0.5.0
+   */
+  findQuoteAuthorization(
+    interactingObject: URL,
+  ): Promise<QuoteAuthorization | undefined> {
+    return this.repository.findQuoteAuthorization(
+      this.identifier,
+      interactingObject,
+    );
+  }
+
+  /**
+   * Removes a quote authorization stamp from the repository.
+   * @param id The UUID of the quote authorization.
+   * @returns The removed quote authorization stamp, or `undefined`.
+   * @since 0.5.0
+   */
+  removeQuoteAuthorization(
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    return this.repository.removeQuoteAuthorization(this.identifier, id);
+  }
 }
 
 /**
@@ -717,6 +824,17 @@ export class KvRepository implements Repository {
     return [...this.prefix, "index", "followees", followeeId.href];
   }
 
+  #quoteAuthorizationIndexKey(
+    identifier: string,
+    interactingObject: URL,
+  ): KvKey {
+    return this.#key(
+      identifier,
+      "quoteAuthorizationsByInteractingObject",
+      interactingObject.href,
+    );
+  }
+
   /**
    * Migrates data stored by BotKit 0.4 or earlier, which was not scoped by
    * bot actor identifiers, so that it belongs to the given identifier.
@@ -764,6 +882,8 @@ export class KvRepository implements Repository {
       "followRequests",
       "followees",
       "follows",
+      "quoteAuthorizations",
+      "quoteAuthorizationsByInteractingObject",
       "polls",
     ] as const;
     for (const category of categories) {
@@ -1440,6 +1560,79 @@ export class KvRepository implements Repository {
     for (const identifier of identifiers) yield identifier;
   }
 
+  async addQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+    authorization: QuoteAuthorization,
+  ): Promise<void> {
+    const interactingObject = authorization.interactingObjectId;
+    if (interactingObject == null) {
+      throw new TypeError(
+        "The quote authorization interacting object is missing.",
+      );
+    }
+    const existing = await this.kv.get<Uuid>(
+      this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+    );
+    if (existing != null) return;
+    await this.kv.set(
+      this.#key(identifier, "quoteAuthorizations", id),
+      await authorization.toJsonLd({ format: "compact" }),
+    );
+    await this.kv.set(
+      this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+      id,
+    );
+  }
+
+  async getQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    const json = await this.kv.get(
+      this.#key(identifier, "quoteAuthorizations", id),
+    );
+    if (json == null) return undefined;
+    try {
+      return await QuoteAuthorization.fromJsonLd(json);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async findQuoteAuthorization(
+    identifier: string,
+    interactingObject: URL,
+  ): Promise<QuoteAuthorization | undefined> {
+    const id = await this.kv.get<Uuid>(
+      this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+    );
+    if (id == null) return undefined;
+    const authorization = await this.getQuoteAuthorization(identifier, id);
+    if (authorization == null) {
+      await this.kv.delete(
+        this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+      );
+    }
+    return authorization;
+  }
+
+  async removeQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    const authorization = await this.getQuoteAuthorization(identifier, id);
+    if (authorization == null) return undefined;
+    await this.kv.delete(this.#key(identifier, "quoteAuthorizations", id));
+    const interactingObject = authorization.interactingObjectId;
+    if (interactingObject != null) {
+      await this.kv.delete(
+        this.#quoteAuthorizationIndexKey(identifier, interactingObject),
+      );
+    }
+    return authorization;
+  }
+
   async #addToFolloweeIndex(
     identifier: string,
     followeeId: URL,
@@ -1606,6 +1799,8 @@ interface MemoryActorData {
   followRequests: Record<string, string>;
   sentFollows: Record<string, Follow>;
   followees: Record<string, Follow>;
+  quoteAuthorizations: Map<Uuid, QuoteAuthorization>;
+  quoteAuthorizationsByInteractingObject: Map<string, Uuid>;
   polls: Record<Uuid, Record<string, Set<string>>>;
 }
 
@@ -1625,6 +1820,8 @@ export class MemoryRepository implements Repository {
         followRequests: {},
         sentFollows: {},
         followees: {},
+        quoteAuthorizations: new Map(),
+        quoteAuthorizationsByInteractingObject: new Map(),
         polls: {},
       };
       this.#data.set(identifier, data);
@@ -1845,6 +2042,67 @@ export class MemoryRepository implements Repository {
     for (const [identifier, data] of this.#data) {
       if (followeeId.href in data.followees) yield identifier;
     }
+  }
+
+  addQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+    authorization: QuoteAuthorization,
+  ): Promise<void> {
+    const interactingObject = authorization.interactingObjectId;
+    if (interactingObject == null) {
+      throw new TypeError(
+        "The quote authorization interacting object is missing.",
+      );
+    }
+    const data = this.#bucket(identifier);
+    if (
+      data.quoteAuthorizationsByInteractingObject.has(interactingObject.href)
+    ) {
+      return Promise.resolve();
+    }
+    data.quoteAuthorizations.set(id, authorization);
+    data.quoteAuthorizationsByInteractingObject.set(interactingObject.href, id);
+    return Promise.resolve();
+  }
+
+  getQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    return Promise.resolve(
+      this.#data.get(identifier)?.quoteAuthorizations.get(id),
+    );
+  }
+
+  findQuoteAuthorization(
+    identifier: string,
+    interactingObject: URL,
+  ): Promise<QuoteAuthorization | undefined> {
+    const data = this.#data.get(identifier);
+    if (data == null) return Promise.resolve(undefined);
+    const id = data.quoteAuthorizationsByInteractingObject.get(
+      interactingObject.href,
+    );
+    if (id == null) return Promise.resolve(undefined);
+    return Promise.resolve(data.quoteAuthorizations.get(id));
+  }
+
+  removeQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    const data = this.#data.get(identifier);
+    if (data == null) return Promise.resolve(undefined);
+    const authorization = data.quoteAuthorizations.get(id);
+    data.quoteAuthorizations.delete(id);
+    const interactingObject = authorization?.interactingObjectId;
+    if (interactingObject != null) {
+      data.quoteAuthorizationsByInteractingObject.delete(
+        interactingObject.href,
+      );
+    }
+    return Promise.resolve(authorization);
   }
 
   vote(
@@ -2137,6 +2395,53 @@ export class MemoryCachedRepository implements Repository {
   // set of followees
   findFollowedBots(followeeId: URL): AsyncIterable<string> {
     return this.underlying.findFollowedBots(followeeId);
+  }
+
+  async addQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+    authorization: QuoteAuthorization,
+  ): Promise<void> {
+    await this.underlying.addQuoteAuthorization(identifier, id, authorization);
+  }
+
+  async getQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    let authorization = await this.cache.getQuoteAuthorization(identifier, id);
+    if (authorization === undefined) {
+      authorization = await this.underlying.getQuoteAuthorization(
+        identifier,
+        id,
+      );
+      if (authorization !== undefined) {
+        await this.cache.addQuoteAuthorization(identifier, id, authorization);
+      }
+    }
+    return authorization;
+  }
+
+  async findQuoteAuthorization(
+    identifier: string,
+    interactingObject: URL,
+  ): Promise<QuoteAuthorization | undefined> {
+    return await this.underlying.findQuoteAuthorization(
+      identifier,
+      interactingObject,
+    );
+  }
+
+  async removeQuoteAuthorization(
+    identifier: string,
+    id: Uuid,
+  ): Promise<QuoteAuthorization | undefined> {
+    const removed = await this.underlying.removeQuoteAuthorization(
+      identifier,
+      id,
+    );
+    await this.cache.removeQuoteAuthorization(identifier, id);
+    return removed;
   }
 
   async vote(

--- a/packages/botkit/src/repository.ts
+++ b/packages/botkit/src/repository.ts
@@ -52,6 +52,20 @@ function isLegacyKvLock(value: unknown): value is string {
   return typeof value === "string" && !uuidPattern.test(value);
 }
 
+function getRawQuoteAuthorizationInteractingObject(
+  json: unknown,
+): URL | undefined {
+  if (typeof json !== "object" || json == null) return undefined;
+  if (!("interactingObject" in json)) return undefined;
+  const interactingObject = json.interactingObject;
+  if (typeof interactingObject !== "string") return undefined;
+  try {
+    return new URL(interactingObject);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * A UUID (universally unique identifier).
  * @since 0.3.0
@@ -1638,28 +1652,31 @@ export class KvRepository implements Repository {
     identifier: string,
     id: Uuid,
   ): Promise<QuoteAuthorization | undefined> {
-    const authorization = await this.getQuoteAuthorization(identifier, id);
-    if (authorization == null) return undefined;
-    const interactingObject = authorization.interactingObjectId;
+    const key = this.#key(identifier, "quoteAuthorizations", id);
+    const json = await this.kv.get(key);
+    if (json == null) return undefined;
+    const interactingObject = getRawQuoteAuthorizationInteractingObject(json);
     if (interactingObject == null) {
-      await this.kv.delete(this.#key(identifier, "quoteAuthorizations", id));
-      return authorization;
+      await this.kv.delete(key);
+    } else {
+      const indexKey = this.#quoteAuthorizationIndexKey(
+        identifier,
+        interactingObject,
+      );
+      await this.#withKvLock(
+        this.#quoteAuthorizationLockKey(identifier, interactingObject),
+        async () => {
+          await this.kv.delete(key);
+          const indexedId = await this.kv.get<Uuid>(indexKey);
+          if (indexedId === id) await this.kv.delete(indexKey);
+        },
+      );
     }
-    await this.#withKvLock(
-      this.#quoteAuthorizationLockKey(identifier, interactingObject),
-      async () => {
-        await this.kv.delete(this.#key(identifier, "quoteAuthorizations", id));
-        const indexedId = await this.kv.get<Uuid>(
-          this.#quoteAuthorizationIndexKey(identifier, interactingObject),
-        );
-        if (indexedId === id) {
-          await this.kv.delete(
-            this.#quoteAuthorizationIndexKey(identifier, interactingObject),
-          );
-        }
-      },
-    );
-    return authorization;
+    try {
+      return await QuoteAuthorization.fromJsonLd(json);
+    } catch {
+      return undefined;
+    }
   }
 
   async #addToFolloweeIndex(

--- a/packages/botkit/src/session-impl.test.ts
+++ b/packages/botkit/src/session-impl.test.ts
@@ -342,6 +342,30 @@ test("SessionImpl.publish()", async (t) => {
     assert.deepStrictEqual(publicMsg.html, "<p>Hello, world!</p>");
     assert.deepStrictEqual(publicMsg.visibility, "public");
     assert.deepStrictEqual(publicMsg.mentions, []);
+    assert.deepStrictEqual(
+      object.interactionPolicy?.canQuote
+        ?.automaticApprovals,
+      [PUBLIC_COLLECTION],
+    );
+  });
+
+  await t.test("quotePolicy", async () => {
+    ctx.sentActivities = [];
+    const followersMsg = await session.publish(text`Followers can quote`, {
+      quotePolicy: "followers",
+    });
+    const activity = ctx.sentActivities[0].activity;
+    assert.ok(activity instanceof Create);
+    const object = await activity.getObject(ctx);
+    assert.ok(object instanceof Note);
+    assert.deepStrictEqual(
+      object.interactionPolicy?.canQuote?.automaticApprovals,
+      [
+        ctx.getActorUri(bot.identifier),
+        ctx.getFollowersUri(bot.identifier),
+      ],
+    );
+    assert.deepStrictEqual(followersMsg.raw.id, object.id);
   });
 
   await t.test("unlisted", async () => {

--- a/packages/botkit/src/session-impl.ts
+++ b/packages/botkit/src/session-impl.ts
@@ -41,6 +41,7 @@ import {
   Question,
 } from "./message.ts";
 import type { Uuid } from "./repository.ts";
+import { serializeQuotePolicy } from "./quote.ts";
 import type {
   Session,
   SessionGetOutboxOptions,
@@ -322,6 +323,11 @@ export class SessionImpl<TContextData> implements Session<TContextData> {
       replyTarget: options.replyTarget?.id,
       quoteUrl: options.quoteTarget?.id,
       tags,
+      interactionPolicy: serializeQuotePolicy(
+        options.quotePolicy ?? this.bot.quotePolicy,
+        this.context.getActorUri(this.bot.identifier),
+        this.context.getFollowersUri(this.bot.identifier),
+      ),
       attribution: this.context.getActorUri(this.bot.identifier),
       attachments: options.attachments ?? [],
       inclusiveOptions,

--- a/packages/botkit/src/session.ts
+++ b/packages/botkit/src/session.ts
@@ -30,6 +30,7 @@ import type {
   MessageVisibility,
 } from "./message.ts";
 import type { Poll } from "./poll.ts";
+import type { QuotePolicyOption } from "./quote.ts";
 import type { Text } from "./text.ts";
 
 /**
@@ -192,6 +193,14 @@ export interface SessionPublishOptions<TContextData> {
    * @since 0.2.0
    */
   readonly quoteTarget?: Message<MessageClass, TContextData>;
+
+  /**
+   * Who can quote the published message.
+   *
+   * If omitted, the bot's default quote policy is used.
+   * @since 0.5.0
+   */
+  readonly quotePolicy?: QuotePolicyOption;
 }
 
 /**

--- a/packages/botkit/src/text.test.ts
+++ b/packages/botkit/src/text.test.ts
@@ -129,6 +129,7 @@ const bot: BotWithVoidContextData = {
         username: "bot",
         class: Service,
         followerPolicy: "accept",
+        quotePolicy: "public",
       },
       context: ctx,
       actorId: ctx.getActorUri(bot.identifier),


### PR DESCRIPTION
This implements the inbound side of [FEP-044f] for BotKit by treating quote authorization as part of the message lifecycle, rather than as a separate callback-only feature.  Outgoing messages now carry an interaction policy, so a remote server can tell whether a quote request should be automatic, manual, or rejected before it asks.  Incoming `QuoteRequest` activities then use the stored message policy as the source of truth, with the bot-level policy kept as a fallback for older messages.

The implementation keeps the request flow explicit.  *packages/botkit/src/quote.ts* defines the policy and request surface, while *packages/botkit/src/quote-impl.ts* owns the Accept/Reject behavior and stamp creation.  `Bot.onQuoteRequest` still runs after automatic handling, because applications may want to observe accepted/rejected requests as well as moderate pending ones.  The `QuoteRequest.state` field makes that distinction visible without asking applications to infer it from side effects.

Accepted requests store `QuoteAuthorization` stamps in the repository layer. The memory, SQLite, and PostgreSQL repositories all index stamps by the remote quote object URI, because that is the stable handle a bot is likely to have when it later needs to revoke a quote.  Duplicate requests preserve the first stamp so repeated delivery and concurrent delivery stay idempotent.  Revocation also works when the caller only has the quote URI and the remote quote cannot be fetched anymore; the local stamp is removed first, then BotKit sends the best federation notification it can.

Dynamic bot groups use the same target resolution path as other inbox activities, so quote requests for dynamically resolved actors are not limited to statically registered bots.  PostgreSQL schema initialization now takes an advisory transaction lock around the schema DDL as well, which avoids catalog races when multiple test/runtime processes initialize the same schema at once.

The public API is documented in *docs/concepts/bot.md*, *docs/concepts/events.md*, and *docs/concepts/message.md*.  The changelog entry in *CHANGES.md* records the new quote policy API, the quote request event, the revocation method, and the repository storage additions.

Closes #28.

[FEP-044f]: https://w3id.org/fep/044f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inbound, consent-respecting quote-request handling with configurable quote policies and a manual `onQuoteRequest` decision hook.
  * Extended message publishing/updating with per-message `quotePolicy`, plus quote-authorization and unauthorization flows.
  * Introduced a public quote module (`quote`) with quote request/policy types and policy normalization/serialization helpers, and wired new bot/event handlers.
  * Added persistent quote-authorization storage across repository implementations (including SQLite/PostgreSQL schema support).
* **Bug Fixes**
  * Improved quote-authorization deduplication, cleanup, and race-safe persistence.
* **Documentation**
  * Expanded concepts and events documentation for quote policies and quote-request handling with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->