### PR TITLE
Verify FEP-044f quote authorization stamps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,7 +48,7 @@ To be released.
     at the root.
 
  -  Added support for consent-respecting quote posts using [FEP-044f].
-    [[#27], [#28], [#29], [#31], [#32]]
+    [[#27], [#28], [#29], [#30], [#31], [#32], [#33]]
 
     BotKit now serializes quote policies on outgoing messages, handles
     incoming `QuoteRequest` activities, automatically accepts or rejects them
@@ -62,6 +62,9 @@ To be released.
     sends a `QuoteRequest` to the quoted message's author, applies accepted
     `QuoteAuthorization` stamps to the stored message, and strips rejected
     quote targets from the stored message before delivering an `Update`.
+    BotKit also verifies `QuoteAuthorization` stamps on received third-party
+    quote posts and handles deleted stamps by forwarding the `Delete` activity
+    before stripping the quote from the bot's own post.
 
      -  Added `QuotePolicy`, `QuotePolicyOption`, `QuoteRequest`, and
         `QuoteRequestEventHandler` types.  [[#27], [#28], [#31]]
@@ -70,6 +73,8 @@ To be released.
         types.  [[#27], [#29], [#32]]
      -  Added `Bot.onQuoteAccepted` and `Bot.onQuoteRejected` event handlers.
         [[#27], [#29], [#32]]
+     -  Added `QuoteRevokedEventHandler` type and `Bot.onQuoteRevoked` event
+        handler.  [[#27], [#30], [#33]]
      -  Added `ReadonlyBot.quotePolicy`, `CreateBotOptions.quotePolicy`, and
         `BotProfile.quotePolicy` properties.  [[#27], [#28], [#31]]
      -  Added `SessionPublishOptions.quotePolicy` and
@@ -77,6 +82,9 @@ To be released.
         [[#27], [#28], [#31]]
      -  Added `Message.quotePolicy` and `AuthorizedMessage.quoteApprovalState`
         properties.  [[#27], [#29], [#32]]
+     -  Added `Message.quoteApproved` property for inspecting whether a
+        received quote post has valid FEP-044f approval.
+        [[#27], [#30], [#33]]
      -  Added `AuthorizedMessage.unauthorizeQuote()` method for revoking an
         existing quote authorization stamp by the quoted message or its URI.
         [[#27], [#28], [#31]]
@@ -98,9 +106,11 @@ To be released.
         `Repository.removeQuoteAuthorization()`.
      -  Added quote authorization reference methods:
         `Repository.addQuoteAuthorizationReference()`,
-        `Repository.findQuoteAuthorizationReference()`, and
+        `Repository.findQuoteAuthorizationReference()`,
+        `Repository.findQuoteAuthorizationReferenceIdentifiers()`,
+        `Repository.findQuoteAuthorizationReferenceAttribution()`, and
         `Repository.removeQuoteAuthorizationReference()`.
-        [[#27], [#29], [#32]]
+        [[#27], [#29], [#30], [#32], [#33]]
      -  Added optional `Repository.migrate()` method for adopting data
         stored by BotKit 0.4 or earlier.
      -  Added `Repository.forIdentifier()` method and `ActorScopedRepository`
@@ -136,8 +146,10 @@ To be released.
 [#27]: https://github.com/fedify-dev/botkit/issues/27
 [#28]: https://github.com/fedify-dev/botkit/issues/28
 [#29]: https://github.com/fedify-dev/botkit/issues/29
+[#30]: https://github.com/fedify-dev/botkit/issues/30
 [#31]: https://github.com/fedify-dev/botkit/pull/31
 [#32]: https://github.com/fedify-dev/botkit/pull/32
+[#33]: https://github.com/fedify-dev/botkit/pull/33
 
 ### @fedify/botkit-sqlite
 

--- a/deno.lock
+++ b/deno.lock
@@ -28,6 +28,7 @@
     "npm:@fedify/markdown-it-mention@0.3": "0.3.0",
     "npm:@fedify/vocab@^2.3.1": "2.3.1",
     "npm:@js-temporal/polyfill@~0.5.1": "0.5.1",
+    "npm:@logtape/logtape@*": "2.2.3",
     "npm:@logtape/logtape@^2.2.3": "2.2.3",
     "npm:@multiformats/base-x@^4.0.1": "4.0.1",
     "npm:@opentelemetry/api@^1.9.1": "1.9.1",

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -313,8 +313,8 @@ the *Message* concept document.
 [FEP-044f]: https://w3id.org/fep/044f
 
 
-Quote accepted and rejected
----------------------------
+Quote accepted, rejected, and revoked
+-------------------------------------
 
 *This API is available since BotKit 0.5.0.*
 
@@ -336,10 +336,9 @@ bot.onQuoteAccepted = (_session, message, approver) => {
 };
 ~~~~
 
-When the request is rejected, or when a previously accepted
-`QuoteAuthorization` stamp is later deleted by the quoted author, BotKit
-removes the quote target and fallback quote link from the stored message,
-sends an `Update` activity, and then calls `~Bot.onQuoteRejected`:
+When the request is rejected, BotKit removes the quote target and fallback
+quote link from the stored message, sends an `Update` activity, and then calls
+`~Bot.onQuoteRejected`:
 
 ~~~~ typescript twoslash
 import { type Bot } from "@fedify/botkit";
@@ -347,6 +346,22 @@ const bot = {} as unknown as Bot<void>;
 // ---cut-before---
 bot.onQuoteRejected = (_session, message, rejecter) => {
   console.log(`${rejecter.id} rejected ${message.id}`);
+  console.log(message.quoteTarget);  // undefined
+};
+~~~~
+
+If a previously accepted `QuoteAuthorization` stamp is later deleted by the
+quoted author's server, BotKit forwards the `Delete` activity to the quote
+post's audience, removes the quote target and fallback quote link from the
+stored message, sends an `Update` activity, and then calls
+`~Bot.onQuoteRevoked`:
+
+~~~~ typescript twoslash
+import { type Bot } from "@fedify/botkit";
+const bot = {} as unknown as Bot<void>;
+// ---cut-before---
+bot.onQuoteRevoked = (_session, message, revoker) => {
+  console.log(`${revoker.id} revoked approval for ${message.id}`);
   console.log(message.quoteTarget);  // undefined
 };
 ~~~~

--- a/docs/concepts/message.md
+++ b/docs/concepts/message.md
@@ -342,9 +342,9 @@ console.log(message.quoteApprovalState);  // "pending"
 
 If the author accepts the quote request, BotKit stores the received
 authorization stamp on the message and sends an `Update` activity.  If the
-author rejects it, BotKit removes the quote target and the fallback quote link
-from the stored message and sends an `Update` activity with the stripped
-content.
+author rejects it, or the author's server later revokes the authorization
+stamp, BotKit removes the quote target and the fallback quote link from the
+stored message and sends an `Update` activity with the stripped content.
 
 ### Polls
 
@@ -618,6 +618,16 @@ object.
 You can get the message that is quoted in the message through
 the `~Message.quoteTarget` property.  It is either another `Message` object
 or `undefined` if the message is not a quote.
+
+For messages received from the fediverse, `~Message.quoteApproved` reports
+whether the quote has FEP-044f approval.  It is `undefined` when the message
+does not quote anything, `true` for self-quotes and quotes with a valid
+`QuoteAuthorization` stamp, and `false` when the stamp is missing, invalid, or
+could not be fetched.  Legacy quote links such as Misskey quote tags and
+`quoteUrl` without a `QuoteAuthorization` stamp are reported as unapproved.
+
+BotKit checks `~Message.quoteApproved` when it materializes the message, so a
+message can reflect a later stamp revocation when it is loaded again.
 
 For authorized messages created by your bot,
 `~AuthorizedMessage.quoteApprovalState` describes whether the quote target

--- a/packages/botkit-postgres/src/mod.test.ts
+++ b/packages/botkit-postgres/src/mod.test.ts
@@ -1104,8 +1104,25 @@ if (postgresUrl == null) {
           undefined,
         );
         assert.deepStrictEqual(
+          await Array.fromAsync(
+            repo.findQuoteAuthorizationReferenceIdentifiers(authorization),
+          ),
+          ["bot"],
+        );
+        assert.deepStrictEqual(
           await repo.findQuoteAuthorizationReference("bot", authorization),
           firstMessageId,
+        );
+        await repo.addQuoteAuthorizationReference(
+          "other",
+          authorization,
+          firstMessageId,
+        );
+        assert.deepStrictEqual(
+          await Array.fromAsync(
+            repo.findQuoteAuthorizationReferenceIdentifiers(authorization),
+          ),
+          ["bot", "other"],
         );
 
         await repo.addQuoteAuthorizationReference(
@@ -1124,6 +1141,12 @@ if (postgresUrl == null) {
         assert.deepStrictEqual(
           await repo.findQuoteAuthorizationReference("bot", authorization),
           undefined,
+        );
+        assert.deepStrictEqual(
+          await Array.fromAsync(
+            repo.findQuoteAuthorizationReferenceIdentifiers(authorization),
+          ),
+          ["other"],
         );
       } finally {
         await harness.cleanup();

--- a/packages/botkit-postgres/src/mod.ts
+++ b/packages/botkit-postgres/src/mod.ts
@@ -299,6 +299,13 @@ async function initializePostgresRepositorySchemaInTransaction(
   );
   await execute(
     sql,
+    `CREATE INDEX IF NOT EXISTS "idx_quote_authorization_refs_authorization"
+       ON "${validatedSchema}"."quote_authorization_refs" (authorization_uri)`,
+    [],
+    prepare,
+  );
+  await execute(
+    sql,
     `ALTER TABLE "${validatedSchema}"."quote_authorization_refs"
        ADD COLUMN IF NOT EXISTS attribution_uri TEXT`,
     [],
@@ -1145,6 +1152,21 @@ export class PostgresRepository implements Repository, AsyncDisposable {
       [identifier, authorization.href],
     );
     return rows[0]?.message_id;
+  }
+
+  async *findQuoteAuthorizationReferenceIdentifiers(
+    authorization: URL,
+  ): AsyncIterable<string> {
+    await this.ensureReady();
+    const rows = await this.query<{ readonly bot_id: string }>(
+      this.sql,
+      `SELECT bot_id
+         FROM ${this.table("quote_authorization_refs")}
+        WHERE authorization_uri = $1
+        ORDER BY bot_id`,
+      [authorization.href],
+    );
+    for (const row of rows) yield row.bot_id;
   }
 
   async findQuoteAuthorizationReferenceAttribution(

--- a/packages/botkit-sqlite/src/mod.test.ts
+++ b/packages/botkit-sqlite/src/mod.test.ts
@@ -388,8 +388,25 @@ describe("SqliteRepository", () => {
         undefined,
       );
       assert.deepStrictEqual(
+        await Array.fromAsync(
+          repo.findQuoteAuthorizationReferenceIdentifiers(authorization),
+        ),
+        ["bot"],
+      );
+      assert.deepStrictEqual(
         await repo.findQuoteAuthorizationReference("bot", authorization),
         firstMessageId,
+      );
+      await repo.addQuoteAuthorizationReference(
+        "other",
+        authorization,
+        firstMessageId,
+      );
+      assert.deepStrictEqual(
+        await Array.fromAsync(
+          repo.findQuoteAuthorizationReferenceIdentifiers(authorization),
+        ),
+        ["bot", "other"],
       );
 
       await repo.addQuoteAuthorizationReference(
@@ -408,6 +425,12 @@ describe("SqliteRepository", () => {
       assert.deepStrictEqual(
         await repo.findQuoteAuthorizationReference("bot", authorization),
         undefined,
+      );
+      assert.deepStrictEqual(
+        await Array.fromAsync(
+          repo.findQuoteAuthorizationReferenceIdentifiers(authorization),
+        ),
+        ["other"],
       );
     } finally {
       repo.close();

--- a/packages/botkit-sqlite/src/mod.ts
+++ b/packages/botkit-sqlite/src/mod.ts
@@ -457,6 +457,10 @@ export class SqliteRepository implements Repository, Disposable {
         PRIMARY KEY (bot_id, authorization)
       )
     `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_quote_authorization_refs_authorization
+      ON quote_authorization_refs(authorization)
+    `);
     if (!this.hasColumn("quote_authorization_refs", "attribution")) {
       this.db.exec(`
         ALTER TABLE quote_authorization_refs ADD COLUMN attribution TEXT
@@ -1125,6 +1129,17 @@ export class SqliteRepository implements Repository, Disposable {
       | { message_id: Uuid }
       | undefined;
     return Promise.resolve(row?.message_id);
+  }
+
+  async *findQuoteAuthorizationReferenceIdentifiers(
+    authorization: URL,
+  ): AsyncIterable<string> {
+    const stmt = this.db.prepare(`
+      SELECT bot_id FROM quote_authorization_refs
+      WHERE authorization = ? ORDER BY bot_id
+    `);
+    const rows = stmt.all(authorization.href) as { bot_id: string }[];
+    for (const row of rows) yield row.bot_id;
   }
 
   findQuoteAuthorizationReferenceAttribution(

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -4867,6 +4867,10 @@ test("BotImpl.onDeleted() forwards quote revocations to reply targets", async ()
     id: new URL("https://reply.example/users/bob"),
     preferredUsername: "bob",
   });
+  const mentioned = new Person({
+    id: new URL("https://mentioned.example/users/carol"),
+    preferredUsername: "carol",
+  });
   const target = new Note({
     id: new URL("https://remote.example/notes/original"),
     attribution: author,
@@ -4879,22 +4883,31 @@ test("BotImpl.onDeleted() forwards quote revocations to reply targets", async ()
     content: "Thread starter.",
     to: PUBLIC_COLLECTION,
   });
+  let replyTargetLookups = 0;
+  let mentionedLookups = 0;
   Object.defineProperty(ctx, "lookupObject", {
-    value: (id: URL) =>
-      Promise.resolve(
-        id.href === target.id?.href
-          ? target
-          : id.href === replyTarget.id?.href
-          ? replyTarget
-          : null,
-      ),
+    value: (id: URL) => {
+      if (id.href === target.id?.href) return Promise.resolve(target);
+      if (id.href === replyTarget.id?.href) {
+        replyTargetLookups++;
+        return Promise.resolve(replyTarget);
+      }
+      if (id.href === mentioned.id?.href) {
+        mentionedLookups++;
+        return Promise.resolve(mentioned);
+      }
+      return Promise.resolve(null);
+    },
   });
   const targetMessage = await createMessage(target, session, {});
   const replyMessage = await createMessage(replyTarget, session, {});
-  const quote = await session.publish(text`Please approve this.`, {
-    quoteTarget: targetMessage,
-    replyTarget: replyMessage,
-  });
+  const quote = await session.publish(
+    text`Please approve this, ${mentioned}.`,
+    {
+      quoteTarget: targetMessage,
+      replyTarget: replyMessage,
+    },
+  );
   const parsed = ctx.parseUri(quote.id);
   assert.ok(parsed?.type === "object");
   const messageId = parsed.values.id as Uuid;
@@ -4918,6 +4931,8 @@ test("BotImpl.onDeleted() forwards quote revocations to reply targets", async ()
   ctx.sentActivities = [];
   ctx.forwardedRecipients = [];
   ctx.forwardedActivities = [];
+  replyTargetLookups = 0;
+  mentionedLookups = 0;
 
   await bot.onDeleted(
     ctx,
@@ -4929,14 +4944,18 @@ test("BotImpl.onDeleted() forwards quote revocations to reply targets", async ()
 
   assert.deepStrictEqual(ctx.forwardedRecipients, [
     "followers",
+    mentioned,
     replyAuthor,
     author,
   ]);
   assert.deepStrictEqual(ctx.forwardedActivities.length, 2);
-  assert.deepStrictEqual(ctx.sentActivities.length, 3);
+  assert.deepStrictEqual(ctx.sentActivities.length, 4);
   assert.deepStrictEqual(ctx.sentActivities[0].recipients, "followers");
-  assert.deepStrictEqual(ctx.sentActivities[1].recipients, [replyAuthor]);
-  assert.deepStrictEqual(ctx.sentActivities[2].recipients, [author]);
+  assert.deepStrictEqual(ctx.sentActivities[1].recipients, [mentioned]);
+  assert.deepStrictEqual(ctx.sentActivities[2].recipients, [replyAuthor]);
+  assert.deepStrictEqual(ctx.sentActivities[3].recipients, [author]);
+  assert.deepStrictEqual(replyTargetLookups, 2);
+  assert.deepStrictEqual(mentionedLookups, 2);
 });
 
 test("BotImpl.onDeleted() forwards private quote revocations only to the quote audience", async () => {

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -2099,12 +2099,21 @@ test("BotImpl.onCreated()", async (t) => {
 
     await bot.onCreated(ctx, create);
 
-    assert.deepStrictEqual(quoted, []);
+    assert.deepStrictEqual(quoted.length, 1);
+    const [, msg] = quoted[0];
+    assert.ok(msg.quoteTarget != null);
+    assert.deepStrictEqual(
+      msg.quoteTarget.id,
+      new URL(
+        "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
+      ),
+    );
+    assert.deepStrictEqual(msg.quoteApproved, false);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged, []);
+    assert.deepStrictEqual(messaged, quoted);
     assert.deepStrictEqual(ctx.sentActivities, []);
-    assert.deepStrictEqual(ctx.forwardedRecipients, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
 
     quoted = [];
     messaged = [];
@@ -2147,12 +2156,16 @@ test("BotImpl.onCreated()", async (t) => {
 
     await bot.onCreated(ctx, create);
 
-    assert.deepStrictEqual(quoted, []);
+    assert.deepStrictEqual(quoted.length, 1);
+    const [, msg] = quoted[0];
+    assert.ok(msg.quoteTarget != null);
+    assert.deepStrictEqual(msg.quoteTarget.id, targetId);
+    assert.deepStrictEqual(msg.quoteApproved, false);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged, []);
+    assert.deepStrictEqual(messaged, quoted);
     assert.deepStrictEqual(ctx.sentActivities, []);
-    assert.deepStrictEqual(ctx.forwardedRecipients, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
 
     quoted = [];
     messaged = [];
@@ -2213,6 +2226,7 @@ test("BotImpl.onCreated()", async (t) => {
       msg.quoteTarget.id,
       targetId,
     );
+    assert.deepStrictEqual(msg.quoteApproved, true);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
     assert.deepStrictEqual(messaged, quoted);
@@ -2275,6 +2289,7 @@ test("BotImpl.onCreated()", async (t) => {
     const [, msg] = quoted[0];
     assert.ok(msg.quoteTarget != null);
     assert.deepStrictEqual(msg.quoteTarget.id, targetId);
+    assert.deepStrictEqual(msg.quoteApproved, true);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
     assert.deepStrictEqual(messaged, quoted);
@@ -2368,6 +2383,7 @@ test("BotImpl.onCreated()", async (t) => {
       msg.quoteTarget.id,
       fepTargetId,
     );
+    assert.deepStrictEqual(msg.quoteApproved, true);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
     assert.deepStrictEqual(messaged, quoted);
@@ -2443,10 +2459,14 @@ test("BotImpl.onCreated()", async (t) => {
 
     await bot.onCreated(ctx, create);
 
-    assert.deepStrictEqual(quoted, []);
+    assert.deepStrictEqual(quoted.length, 1);
+    const [, msg] = quoted[0];
+    assert.ok(msg.quoteTarget != null);
+    assert.deepStrictEqual(msg.quoteTarget.id, targetId);
+    assert.deepStrictEqual(msg.quoteApproved, false);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged, []);
+    assert.deepStrictEqual(messaged, quoted);
     assert.deepStrictEqual(ctx.sentActivities.length, 2);
     const [actorDelete, followersDelete] = ctx.sentActivities;
     assert.deepStrictEqual(
@@ -2458,7 +2478,7 @@ test("BotImpl.onCreated()", async (t) => {
     assert.deepStrictEqual(followersDelete.recipients, "followers");
     assert.ok(followersDelete.activity instanceof Delete);
     assert.deepStrictEqual(followersDelete.activity.objectId, authorizationUrl);
-    assert.deepStrictEqual(ctx.forwardedRecipients, []);
+    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
 
     quoted = [];
     messaged = [];
@@ -3195,6 +3215,10 @@ interface SentActivity {
 interface MockInboxContext extends InboxContext<void> {
   sentActivities: SentActivity[];
   forwardedRecipients: ("followers" | Recipient)[];
+  forwardedActivities: {
+    recipients: "followers" | Recipient[];
+    options: unknown;
+  }[];
 }
 
 function createMockInboxContext(
@@ -3224,7 +3248,16 @@ function createMockInboxContext(
     return Promise.resolve();
   };
   ctx.forwardedRecipients = [];
-  ctx.forwardActivity = (_, recipients) => {
+  ctx.forwardedActivities = [];
+  ctx.forwardActivity = (_, recipients, options) => {
+    ctx.forwardedActivities.push({
+      recipients: recipients === "followers"
+        ? "followers"
+        : Array.isArray(recipients)
+        ? recipients
+        : [recipients],
+      options,
+    });
     if (recipients === "followers") {
       ctx.forwardedRecipients.push("followers");
     } else if (Array.isArray(recipients)) {
@@ -4401,13 +4434,19 @@ test("BotImpl.onDeleted() strips revoked quote authorizations", async () => {
     ),
     messageId,
   );
-  let rejected: AuthorizedMessage<MessageClass, void> | undefined;
-  let rejecter: Actor | undefined;
-  bot.onQuoteRejected = (_session, message, actor) => {
-    rejected = message;
-    rejecter = actor;
+  let rejectedCalled = false;
+  let revoked: AuthorizedMessage<MessageClass, void> | undefined;
+  let revoker: Actor | undefined;
+  bot.onQuoteRejected = () => {
+    rejectedCalled = true;
+  };
+  bot.onQuoteRevoked = (_session, message, actor) => {
+    revoked = message;
+    revoker = actor;
   };
   ctx.sentActivities = [];
+  ctx.forwardedRecipients = [];
+  ctx.forwardedActivities = [];
 
   await bot.onDeleted(
     ctx,
@@ -4433,17 +4472,28 @@ test("BotImpl.onDeleted() strips revoked quote authorizations", async () => {
     ),
     undefined,
   );
+  assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+  assert.deepStrictEqual(ctx.forwardedActivities.length, 1);
+  assert.deepStrictEqual(
+    ctx.forwardedActivities[0].options,
+    {
+      skipIfUnsigned: true,
+      preferSharedInbox: true,
+      excludeBaseUris: [new URL("https://example.com")],
+    },
+  );
   assert.deepStrictEqual(ctx.sentActivities.length, 2);
   assert.deepStrictEqual(ctx.sentActivities[0].recipients, "followers");
   assert.ok(ctx.sentActivities[0].activity instanceof Update);
   assert.deepStrictEqual(ctx.sentActivities[1].recipients, [author]);
   assert.ok(ctx.sentActivities[1].activity instanceof Update);
-  assert.deepStrictEqual(rejected?.id, quote.id);
-  assert.deepStrictEqual(rejected?.quoteTarget, undefined);
-  assert.deepStrictEqual(rejecter?.id, author.id);
+  assert.deepStrictEqual(rejectedCalled, false);
+  assert.deepStrictEqual(revoked?.id, quote.id);
+  assert.deepStrictEqual(revoked?.quoteTarget, undefined);
+  assert.deepStrictEqual(revoker?.id, author.id);
 });
 
-test("BotImpl.onDeleted() ignores quote revocations from other actors", async () => {
+test("BotImpl.onDeleted() strips quote revocations from same-origin actors", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({
     kv: new MemoryKvStore(),
@@ -4494,7 +4544,15 @@ test("BotImpl.onDeleted() ignores quote revocations from other actors", async ()
       result: authorization,
     }),
   );
+  let revoked: AuthorizedMessage<MessageClass, void> | undefined;
+  let revoker: Actor | undefined;
+  bot.onQuoteRevoked = (_session, message, actor) => {
+    revoked = message;
+    revoker = actor;
+  };
   ctx.sentActivities = [];
+  ctx.forwardedRecipients = [];
+  ctx.forwardedActivities = [];
 
   await bot.onDeleted(
     ctx,
@@ -4508,15 +4566,84 @@ test("BotImpl.onDeleted() ignores quote revocations from other actors", async ()
   assert.ok(stored instanceof Create);
   const object = await stored.getObject(ctx);
   assert.ok(object instanceof Note);
-  assert.deepStrictEqual(object.quoteAuthorizationId, authorization.id);
+  assert.deepStrictEqual(object.quoteId, null);
+  assert.deepStrictEqual(object.quoteAuthorizationId, null);
   assert.deepStrictEqual(
     await repository.findQuoteAuthorizationReference(
       "bot",
       authorization.id!,
     ),
+    undefined,
+  );
+  assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+  assert.deepStrictEqual(ctx.forwardedActivities.length, 1);
+  assert.deepStrictEqual(ctx.sentActivities.length, 2);
+  assert.deepStrictEqual(ctx.sentActivities[0].recipients, "followers");
+  assert.ok(ctx.sentActivities[0].activity instanceof Update);
+  assert.deepStrictEqual(ctx.sentActivities[1].recipients, [otherActor]);
+  assert.ok(ctx.sentActivities[1].activity instanceof Update);
+  assert.deepStrictEqual(revoked?.id, quote.id);
+  assert.deepStrictEqual(revoked?.quoteTarget, undefined);
+  assert.deepStrictEqual(revoker?.id, otherActor.id);
+});
+
+test("BotImpl.onDeleted() ignores quote revocations from wrong origins", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const messageId = "01950000-0000-7000-8000-000000000205" as Uuid;
+  const authorization = new URL("https://remote.example/stamps/1");
+  const revoker = new Person({
+    id: new URL("https://evil.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  await repository.addMessage(
+    "bot",
+    messageId,
+    new Create({
+      id: new URL(`https://example.com/ap/actor/bot/create/${messageId}`),
+      actor: new URL("https://example.com/ap/actor/bot"),
+      to: PUBLIC_COLLECTION,
+      object: new Note({
+        id: new URL(`https://example.com/ap/actor/bot/note/${messageId}`),
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        content: "Quote.",
+        to: PUBLIC_COLLECTION,
+        quote: new URL("https://remote.example/notes/original"),
+        quoteAuthorization: authorization,
+      }),
+    }),
+  );
+  await repository.addQuoteAuthorizationReference(
+    "bot",
+    authorization,
+    messageId,
+    revoker.id!,
+  );
+  let revoked = false;
+  bot.onQuoteRevoked = () => {
+    revoked = true;
+  };
+
+  await bot.onDeleted(
+    ctx,
+    new Delete({
+      actor: revoker,
+      object: authorization,
+    }),
+  );
+
+  assert.deepStrictEqual(revoked, false);
+  assert.deepStrictEqual(ctx.sentActivities, []);
+  assert.deepStrictEqual(ctx.forwardedRecipients, []);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorizationReference("bot", authorization),
     messageId,
   );
-  assert.deepStrictEqual(ctx.sentActivities.length, 0);
 });
 
 test("BotImpl.onDeleted() strips revoked quotes with missing targets", async () => {

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -4527,8 +4527,8 @@ test("BotImpl.onDeleted() strips revoked quote authorizations", async () => {
     ),
     undefined,
   );
-  assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
-  assert.deepStrictEqual(ctx.forwardedActivities.length, 1);
+  assert.deepStrictEqual(ctx.forwardedRecipients, ["followers", author]);
+  assert.deepStrictEqual(ctx.forwardedActivities.length, 2);
   assert.deepStrictEqual(
     ctx.forwardedActivities[0].options,
     {
@@ -4687,8 +4687,8 @@ test("BotImpl.onDeleted() keeps newer quote authorizations", async () => {
     ),
     messageId,
   );
-  assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
-  assert.deepStrictEqual(ctx.forwardedActivities.length, 1);
+  assert.deepStrictEqual(ctx.forwardedRecipients, ["followers", author]);
+  assert.deepStrictEqual(ctx.forwardedActivities.length, 2);
   assert.deepStrictEqual(ctx.sentActivities, []);
   assert.deepStrictEqual(revoked, undefined);
 });
@@ -4782,7 +4782,75 @@ test("BotImpl.onDeleted() ignores same-origin quote revocations without attribut
   assert.deepStrictEqual(revoker, undefined);
 });
 
-test("BotImpl.onDeleted() does not forward private quote revocations to followers", async () => {
+test("BotImpl.onDeleted() forwards quote revocations to mentions", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const messageId = "01950000-0000-7000-8000-000000000209" as Uuid;
+  const author = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const mentioned = new Person({
+    id: new URL("https://mentioned.example/users/bob"),
+    preferredUsername: "bob",
+  });
+  Object.defineProperty(ctx, "lookupObject", {
+    value: (id: URL) =>
+      Promise.resolve(id.href === mentioned.id?.href ? mentioned : null),
+  });
+  const authorization = new URL("https://remote.example/stamps/1");
+  await repository.addMessage(
+    "bot",
+    messageId,
+    new Create({
+      id: new URL(`https://example.com/ap/actor/bot/create/${messageId}`),
+      actor: new URL("https://example.com/ap/actor/bot"),
+      object: new Note({
+        id: new URL(`https://example.com/ap/actor/bot/note/${messageId}`),
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        content: "Quote @bob.",
+        tos: [ctx.getFollowersUri(bot.identifier), mentioned.id!],
+        tags: [new Mention({ href: mentioned.id })],
+        quote: new URL("https://remote.example/notes/original"),
+        quoteAuthorization: authorization,
+      }),
+    }),
+  );
+  await repository.addQuoteAuthorizationReference(
+    "bot",
+    authorization,
+    messageId,
+    author.id!,
+  );
+
+  await bot.onDeleted(
+    ctx,
+    new Delete({
+      actor: author,
+      object: authorization,
+    }),
+  );
+
+  const stored = await repository.getMessage("bot", messageId);
+  assert.ok(stored instanceof Create);
+  const object = await stored.getObject(ctx);
+  assert.ok(object instanceof Note);
+  assert.deepStrictEqual(object.quoteId, null);
+  assert.deepStrictEqual(object.quoteAuthorizationId, null);
+  assert.deepStrictEqual(ctx.forwardedRecipients, [
+    "followers",
+    mentioned,
+    author,
+  ]);
+  assert.deepStrictEqual(ctx.forwardedActivities.length, 2);
+});
+
+test("BotImpl.onDeleted() forwards private quote revocations only to the quote audience", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({
     kv: new MemoryKvStore(),
@@ -4837,8 +4905,8 @@ test("BotImpl.onDeleted() does not forward private quote revocations to follower
     await repository.findQuoteAuthorizationReference("bot", authorization),
     undefined,
   );
-  assert.deepStrictEqual(ctx.forwardedRecipients, []);
-  assert.deepStrictEqual(ctx.forwardedActivities, []);
+  assert.deepStrictEqual(ctx.forwardedRecipients, [author]);
+  assert.deepStrictEqual(ctx.forwardedActivities.length, 1);
   assert.deepStrictEqual(ctx.sentActivities.length, 1);
   assert.deepStrictEqual(ctx.sentActivities[0].recipients, [author]);
   assert.ok(ctx.sentActivities[0].activity instanceof Update);

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -4493,7 +4493,7 @@ test("BotImpl.onDeleted() strips revoked quote authorizations", async () => {
   assert.deepStrictEqual(revoker?.id, author.id);
 });
 
-test("BotImpl.onDeleted() strips quote revocations from same-origin actors", async () => {
+test("BotImpl.onDeleted() ignores same-origin quote revocations without attribution", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({
     kv: new MemoryKvStore(),
@@ -4566,25 +4566,82 @@ test("BotImpl.onDeleted() strips quote revocations from same-origin actors", asy
   assert.ok(stored instanceof Create);
   const object = await stored.getObject(ctx);
   assert.ok(object instanceof Note);
-  assert.deepStrictEqual(object.quoteId, null);
-  assert.deepStrictEqual(object.quoteAuthorizationId, null);
+  assert.deepStrictEqual(object.quoteId, target.id);
+  assert.deepStrictEqual(object.quoteAuthorizationId, authorization.id);
   assert.deepStrictEqual(
     await repository.findQuoteAuthorizationReference(
       "bot",
       authorization.id!,
     ),
+    messageId,
+  );
+  assert.deepStrictEqual(ctx.forwardedRecipients, []);
+  assert.deepStrictEqual(ctx.forwardedActivities, []);
+  assert.deepStrictEqual(ctx.sentActivities, []);
+  assert.deepStrictEqual(revoked, undefined);
+  assert.deepStrictEqual(revoker, undefined);
+});
+
+test("BotImpl.onDeleted() does not forward private quote revocations to followers", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const messageId = "01950000-0000-7000-8000-000000000208" as Uuid;
+  const author = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const authorization = new URL("https://remote.example/stamps/1");
+  await repository.addMessage(
+    "bot",
+    messageId,
+    new Create({
+      id: new URL(`https://example.com/ap/actor/bot/create/${messageId}`),
+      actor: new URL("https://example.com/ap/actor/bot"),
+      object: new Note({
+        id: new URL(`https://example.com/ap/actor/bot/note/${messageId}`),
+        attribution: new URL("https://example.com/ap/actor/bot"),
+        content: "Quote.",
+        to: author.id,
+        quote: new URL("https://remote.example/notes/original"),
+        quoteAuthorization: authorization,
+      }),
+    }),
+  );
+  await repository.addQuoteAuthorizationReference(
+    "bot",
+    authorization,
+    messageId,
+    author.id!,
+  );
+
+  await bot.onDeleted(
+    ctx,
+    new Delete({
+      actor: author,
+      object: authorization,
+    }),
+  );
+
+  const stored = await repository.getMessage("bot", messageId);
+  assert.ok(stored instanceof Create);
+  const object = await stored.getObject(ctx);
+  assert.ok(object instanceof Note);
+  assert.deepStrictEqual(object.quoteId, null);
+  assert.deepStrictEqual(object.quoteAuthorizationId, null);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorizationReference("bot", authorization),
     undefined,
   );
-  assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
-  assert.deepStrictEqual(ctx.forwardedActivities.length, 1);
-  assert.deepStrictEqual(ctx.sentActivities.length, 2);
-  assert.deepStrictEqual(ctx.sentActivities[0].recipients, "followers");
+  assert.deepStrictEqual(ctx.forwardedRecipients, []);
+  assert.deepStrictEqual(ctx.forwardedActivities, []);
+  assert.deepStrictEqual(ctx.sentActivities.length, 1);
+  assert.deepStrictEqual(ctx.sentActivities[0].recipients, [author]);
   assert.ok(ctx.sentActivities[0].activity instanceof Update);
-  assert.deepStrictEqual(ctx.sentActivities[1].recipients, [otherActor]);
-  assert.ok(ctx.sentActivities[1].activity instanceof Update);
-  assert.deepStrictEqual(revoked?.id, quote.id);
-  assert.deepStrictEqual(revoked?.quoteTarget, undefined);
-  assert.deepStrictEqual(revoker?.id, otherActor.id);
 });
 
 test("BotImpl.onDeleted() ignores quote revocations from wrong origins", async () => {

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -45,6 +45,7 @@ import {
   Undo,
   Update,
 } from "@fedify/vocab";
+import { configureSync, type LogRecord, resetSync } from "@logtape/logtape";
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { BotImpl, MigrationGatedRepository } from "./bot-impl.ts";
@@ -59,9 +60,10 @@ import type {
 } from "./message.ts";
 import type { Vote } from "./poll.ts";
 import type { Like, Reaction } from "./reaction.ts";
-import { MemoryRepository, type Repository, type Uuid } from "./repository.ts";
+import { MemoryRepository, type Uuid } from "./repository.ts";
 import { SessionImpl } from "./session-impl.ts";
 import type { Session } from "./session.ts";
+import { hideRepositoryMethods } from "./helpers.ts";
 import { mention, strong, text } from "./text.ts";
 
 describe("BotImpl.getActorSummary()", () => {
@@ -2865,16 +2867,70 @@ test("BotImpl.dispatchNodeInfo()", () => {
 test("MigrationGatedRepository tolerates missing quote reference indexes", async () => {
   const underlying = hideRepositoryMethods(new MemoryRepository(), [
     "findQuoteAuthorizationReferenceIdentifiers",
+    "findQuoteAuthorizationReferenceAttribution",
   ]);
   const repository = new MigrationGatedRepository(underlying, "bot");
+  const records: LogRecord[] = [];
 
-  assert.deepStrictEqual(
-    await Array.fromAsync(
-      repository.findQuoteAuthorizationReferenceIdentifiers(
+  configureSync({
+    sinks: {
+      capture: (record) => records.push(record),
+    },
+    loggers: [
+      {
+        category: ["botkit", "bot"],
+        sinks: ["capture"],
+        lowestLevel: "warning",
+      },
+      {
+        category: ["logtape", "meta"],
+        lowestLevel: null,
+      },
+    ],
+    reset: true,
+  });
+
+  try {
+    assert.deepStrictEqual(
+      await Array.fromAsync(
+        repository.findQuoteAuthorizationReferenceIdentifiers(
+          new URL("https://remote.example/stamps/1"),
+        ),
+      ),
+      [],
+    );
+    assert.deepStrictEqual(
+      await Array.fromAsync(
+        repository.findQuoteAuthorizationReferenceIdentifiers(
+          new URL("https://remote.example/stamps/1"),
+        ),
+      ),
+      [],
+    );
+    assert.deepStrictEqual(
+      await repository.findQuoteAuthorizationReferenceAttribution(
+        "bot",
         new URL("https://remote.example/stamps/1"),
       ),
-    ),
-    [],
+      undefined,
+    );
+    assert.deepStrictEqual(
+      await repository.findQuoteAuthorizationReferenceAttribution(
+        "bot",
+        new URL("https://remote.example/stamps/1"),
+      ),
+      undefined,
+    );
+  } finally {
+    resetSync();
+  }
+
+  assert.deepStrictEqual(
+    records.map((record) => record.properties.method),
+    [
+      "findQuoteAuthorizationReferenceIdentifiers",
+      "findQuoteAuthorizationReferenceAttribution",
+    ],
   );
 });
 
@@ -3267,19 +3323,6 @@ function createMockInboxContext(
     return Promise.resolve();
   };
   return ctx;
-}
-
-function hideRepositoryMethods(
-  repository: Repository,
-  hiddenMethods: readonly PropertyKey[],
-): Repository {
-  return new Proxy(repository, {
-    get(target, prop, receiver) {
-      if (hiddenMethods.includes(prop)) return undefined;
-      const value = Reflect.get(target, prop, receiver);
-      return typeof value === "function" ? value.bind(target) : value;
-    },
-  });
 }
 
 test("BotImpl.onVote()", async (t) => {
@@ -4503,6 +4546,151 @@ test("BotImpl.onDeleted() strips revoked quote authorizations", async () => {
   assert.deepStrictEqual(revoked?.id, quote.id);
   assert.deepStrictEqual(revoked?.quoteTarget, undefined);
   assert.deepStrictEqual(revoker?.id, author.id);
+});
+
+test("BotImpl.onDeleted() keeps newer quote authorizations", async () => {
+  class ConcurrentQuoteAuthorizationRepository extends MemoryRepository {
+    replaceOnNextUpdate = false;
+
+    constructor(
+      readonly replacementAuthorization: URL,
+      readonly attribution: URL,
+    ) {
+      super();
+    }
+
+    override async updateMessage(
+      identifier: string,
+      id: Uuid,
+      updater: (
+        existing: Create | Announce,
+      ) =>
+        | Create
+        | Announce
+        | undefined
+        | Promise<Create | Announce | undefined>,
+    ): Promise<boolean> {
+      if (identifier === "bot" && this.replaceOnNextUpdate) {
+        this.replaceOnNextUpdate = false;
+        const existing = await this.getMessage(identifier, id);
+        if (existing instanceof Create) {
+          const object = await existing.getObject();
+          if (object instanceof Note) {
+            await super.updateMessage(
+              identifier,
+              id,
+              (current) =>
+                current instanceof Create
+                  ? current.clone({
+                    object: object.clone({
+                      quoteAuthorization: this.replacementAuthorization,
+                    }),
+                  })
+                  : current,
+            );
+            await this.addQuoteAuthorizationReference(
+              identifier,
+              this.replacementAuthorization,
+              id,
+              this.attribution,
+            );
+          }
+        }
+      }
+      return await super.updateMessage(identifier, id, updater);
+    }
+  }
+  const newerAuthorization = new URL("https://remote.example/stamps/2");
+  const author = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const repository = new ConcurrentQuoteAuthorizationRepository(
+    newerAuthorization,
+    author.id!,
+  );
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const target = new Note({
+    id: new URL("https://remote.example/notes/original"),
+    attribution: author,
+    content: "Original.",
+    to: PUBLIC_COLLECTION,
+  });
+  Object.defineProperty(ctx, "lookupObject", {
+    value: (id: URL) =>
+      Promise.resolve(id.href === target.id?.href ? target : null),
+  });
+  const targetMessage = await createMessage(target, session, {});
+  const quote = await session.publish(text`Please approve this.`, {
+    quoteTarget: targetMessage,
+  });
+  const parsed = ctx.parseUri(quote.id);
+  assert.ok(parsed?.type === "object");
+  const messageId = parsed.values.id as Uuid;
+  const revokedAuthorization = new QuoteAuthorization({
+    id: new URL("https://remote.example/stamps/1"),
+    attribution: author.id,
+    interactingObject: quote.id,
+    interactionTarget: target.id,
+  });
+  await bot.onFollowAccepted(
+    ctx,
+    new Accept({
+      actor: author,
+      object: ctx.getObjectUri(QuoteRequest, {
+        identifier: bot.identifier,
+        id: messageId,
+      }),
+      result: revokedAuthorization,
+    }),
+  );
+  let revoked: AuthorizedMessage<MessageClass, void> | undefined;
+  bot.onQuoteRevoked = (_session, message) => {
+    revoked = message;
+  };
+  repository.replaceOnNextUpdate = true;
+  ctx.sentActivities = [];
+  ctx.forwardedRecipients = [];
+  ctx.forwardedActivities = [];
+
+  await bot.onDeleted(
+    ctx,
+    new Delete({
+      actor: author,
+      object: revokedAuthorization.id,
+    }),
+  );
+
+  const stored = await repository.getMessage("bot", messageId);
+  assert.ok(stored instanceof Create);
+  const object = await stored.getObject(ctx);
+  assert.ok(object instanceof Note);
+  assert.deepStrictEqual(object.quoteId, target.id);
+  assert.deepStrictEqual(object.quoteAuthorizationId, newerAuthorization);
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorizationReference(
+      "bot",
+      revokedAuthorization.id!,
+    ),
+    undefined,
+  );
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorizationReference(
+      "bot",
+      newerAuthorization,
+    ),
+    messageId,
+  );
+  assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+  assert.deepStrictEqual(ctx.forwardedActivities.length, 1);
+  assert.deepStrictEqual(ctx.sentActivities, []);
+  assert.deepStrictEqual(revoked, undefined);
 });
 
 test("BotImpl.onDeleted() ignores same-origin quote revocations without attribution", async () => {

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -47,7 +47,7 @@ import {
 } from "@fedify/vocab";
 import assert from "node:assert";
 import { describe, test } from "node:test";
-import { BotImpl } from "./bot-impl.ts";
+import { BotImpl, MigrationGatedRepository } from "./bot-impl.ts";
 import type { CustomEmoji } from "./emoji.ts";
 import type { FollowRequest } from "./follow.ts";
 import { createMessage, isQuoteLink } from "./message-impl.ts";
@@ -59,7 +59,7 @@ import type {
 } from "./message.ts";
 import type { Vote } from "./poll.ts";
 import type { Like, Reaction } from "./reaction.ts";
-import { MemoryRepository, type Uuid } from "./repository.ts";
+import { MemoryRepository, type Repository, type Uuid } from "./repository.ts";
 import { SessionImpl } from "./session-impl.ts";
 import type { Session } from "./session.ts";
 import { mention, strong, text } from "./text.ts";
@@ -2099,21 +2099,12 @@ test("BotImpl.onCreated()", async (t) => {
 
     await bot.onCreated(ctx, create);
 
-    assert.deepStrictEqual(quoted.length, 1);
-    const [, msg] = quoted[0];
-    assert.ok(msg.quoteTarget != null);
-    assert.deepStrictEqual(
-      msg.quoteTarget.id,
-      new URL(
-        "https://example.com/ap/note/a6358f1b-c978-49d3-8065-37a1df6168de",
-      ),
-    );
-    assert.deepStrictEqual(msg.quoteApproved, false);
+    assert.deepStrictEqual(quoted, []);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged, quoted);
+    assert.deepStrictEqual(messaged, []);
     assert.deepStrictEqual(ctx.sentActivities, []);
-    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+    assert.deepStrictEqual(ctx.forwardedRecipients, []);
 
     quoted = [];
     messaged = [];
@@ -2156,16 +2147,12 @@ test("BotImpl.onCreated()", async (t) => {
 
     await bot.onCreated(ctx, create);
 
-    assert.deepStrictEqual(quoted.length, 1);
-    const [, msg] = quoted[0];
-    assert.ok(msg.quoteTarget != null);
-    assert.deepStrictEqual(msg.quoteTarget.id, targetId);
-    assert.deepStrictEqual(msg.quoteApproved, false);
+    assert.deepStrictEqual(quoted, []);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged, quoted);
+    assert.deepStrictEqual(messaged, []);
     assert.deepStrictEqual(ctx.sentActivities, []);
-    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+    assert.deepStrictEqual(ctx.forwardedRecipients, []);
 
     quoted = [];
     messaged = [];
@@ -2459,14 +2446,10 @@ test("BotImpl.onCreated()", async (t) => {
 
     await bot.onCreated(ctx, create);
 
-    assert.deepStrictEqual(quoted.length, 1);
-    const [, msg] = quoted[0];
-    assert.ok(msg.quoteTarget != null);
-    assert.deepStrictEqual(msg.quoteTarget.id, targetId);
-    assert.deepStrictEqual(msg.quoteApproved, false);
+    assert.deepStrictEqual(quoted, []);
     assert.deepStrictEqual(replied, []);
     assert.deepStrictEqual(mentioned, []);
-    assert.deepStrictEqual(messaged, quoted);
+    assert.deepStrictEqual(messaged, []);
     assert.deepStrictEqual(ctx.sentActivities.length, 2);
     const [actorDelete, followersDelete] = ctx.sentActivities;
     assert.deepStrictEqual(
@@ -2478,7 +2461,7 @@ test("BotImpl.onCreated()", async (t) => {
     assert.deepStrictEqual(followersDelete.recipients, "followers");
     assert.ok(followersDelete.activity instanceof Delete);
     assert.deepStrictEqual(followersDelete.activity.objectId, authorizationUrl);
-    assert.deepStrictEqual(ctx.forwardedRecipients, ["followers"]);
+    assert.deepStrictEqual(ctx.forwardedRecipients, []);
 
     quoted = [];
     messaged = [];
@@ -2879,6 +2862,22 @@ test("BotImpl.dispatchNodeInfo()", () => {
   });
 });
 
+test("MigrationGatedRepository tolerates missing quote reference indexes", async () => {
+  const underlying = hideRepositoryMethods(new MemoryRepository(), [
+    "findQuoteAuthorizationReferenceIdentifiers",
+  ]);
+  const repository = new MigrationGatedRepository(underlying, "bot");
+
+  assert.deepStrictEqual(
+    await Array.fromAsync(
+      repository.findQuoteAuthorizationReferenceIdentifiers(
+        new URL("https://remote.example/stamps/1"),
+      ),
+    ),
+    [],
+  );
+});
+
 test("BotImpl.fetch()", async () => {
   const bot = new BotImpl<void>({
     kv: new MemoryKvStore(),
@@ -3268,6 +3267,19 @@ function createMockInboxContext(
     return Promise.resolve();
   };
   return ctx;
+}
+
+function hideRepositoryMethods(
+  repository: Repository,
+  hiddenMethods: readonly PropertyKey[],
+): Repository {
+  return new Proxy(repository, {
+    get(target, prop, receiver) {
+      if (hiddenMethods.includes(prop)) return undefined;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
 }
 
 test("BotImpl.onVote()", async (t) => {

--- a/packages/botkit/src/bot-impl.test.ts
+++ b/packages/botkit/src/bot-impl.test.ts
@@ -4850,6 +4850,95 @@ test("BotImpl.onDeleted() forwards quote revocations to mentions", async () => {
   assert.deepStrictEqual(ctx.forwardedActivities.length, 2);
 });
 
+test("BotImpl.onDeleted() forwards quote revocations to reply targets", async () => {
+  const repository = new MemoryRepository();
+  const bot = new BotImpl<void>({
+    kv: new MemoryKvStore(),
+    repository,
+    username: "bot",
+  });
+  const ctx = createMockInboxContext(bot, "https://example.com", "bot");
+  const session = new SessionImpl(bot, ctx);
+  const author = new Person({
+    id: new URL("https://remote.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const replyAuthor = new Person({
+    id: new URL("https://reply.example/users/bob"),
+    preferredUsername: "bob",
+  });
+  const target = new Note({
+    id: new URL("https://remote.example/notes/original"),
+    attribution: author,
+    content: "Original.",
+    to: PUBLIC_COLLECTION,
+  });
+  const replyTarget = new Note({
+    id: new URL("https://reply.example/notes/thread"),
+    attribution: replyAuthor,
+    content: "Thread starter.",
+    to: PUBLIC_COLLECTION,
+  });
+  Object.defineProperty(ctx, "lookupObject", {
+    value: (id: URL) =>
+      Promise.resolve(
+        id.href === target.id?.href
+          ? target
+          : id.href === replyTarget.id?.href
+          ? replyTarget
+          : null,
+      ),
+  });
+  const targetMessage = await createMessage(target, session, {});
+  const replyMessage = await createMessage(replyTarget, session, {});
+  const quote = await session.publish(text`Please approve this.`, {
+    quoteTarget: targetMessage,
+    replyTarget: replyMessage,
+  });
+  const parsed = ctx.parseUri(quote.id);
+  assert.ok(parsed?.type === "object");
+  const messageId = parsed.values.id as Uuid;
+  const authorization = new QuoteAuthorization({
+    id: new URL("https://remote.example/stamps/1"),
+    attribution: author.id,
+    interactingObject: quote.id,
+    interactionTarget: target.id,
+  });
+  await bot.onFollowAccepted(
+    ctx,
+    new Accept({
+      actor: author,
+      object: ctx.getObjectUri(QuoteRequest, {
+        identifier: bot.identifier,
+        id: messageId,
+      }),
+      result: authorization,
+    }),
+  );
+  ctx.sentActivities = [];
+  ctx.forwardedRecipients = [];
+  ctx.forwardedActivities = [];
+
+  await bot.onDeleted(
+    ctx,
+    new Delete({
+      actor: author,
+      object: authorization.id,
+    }),
+  );
+
+  assert.deepStrictEqual(ctx.forwardedRecipients, [
+    "followers",
+    replyAuthor,
+    author,
+  ]);
+  assert.deepStrictEqual(ctx.forwardedActivities.length, 2);
+  assert.deepStrictEqual(ctx.sentActivities.length, 3);
+  assert.deepStrictEqual(ctx.sentActivities[0].recipients, "followers");
+  assert.deepStrictEqual(ctx.sentActivities[1].recipients, [replyAuthor]);
+  assert.deepStrictEqual(ctx.sentActivities[2].recipients, [author]);
+});
+
 test("BotImpl.onDeleted() forwards private quote revocations only to the quote audience", async () => {
   const repository = new MemoryRepository();
   const bot = new BotImpl<void>({

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -899,6 +899,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     | undefined
   > {
     const quoteId = object.quoteId;
+    const quoteAuthorizationId = object.quoteAuthorizationId;
     let strippedObject: MessageClass | undefined;
     const wasUpdated = await this.repository.updateMessage(
       id,
@@ -907,7 +908,10 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
         const existingObject = await existing.getObject(ctx);
         if (
           !isMessageObject(existingObject) || existingObject.id == null ||
-          (quoteId != null && existingObject.quoteId?.href !== quoteId.href)
+          (quoteId != null && existingObject.quoteId?.href !== quoteId.href) ||
+          (quoteAuthorizationId != null &&
+            existingObject.quoteAuthorizationId?.href !==
+              quoteAuthorizationId.href)
         ) {
           return;
         }
@@ -2221,6 +2225,7 @@ export function wrapBotImpl<TContextData>(
 export class MigrationGatedRepository implements Repository {
   readonly #repository: Repository;
   readonly #migration: Promise<void>;
+  readonly #missingQuoteAuthorizationReferenceMethods = new Set<string>();
 
   constructor(repository: Repository, identifier: string) {
     this.#repository = repository;
@@ -2228,6 +2233,15 @@ export class MigrationGatedRepository implements Repository {
     // The rejection is re-thrown by the first awaiting operation; this
     // no-op handler only prevents an unhandled rejection warning:
     this.#migration.catch(() => {});
+  }
+
+  #warnMissingQuoteAuthorizationReferenceMethod(method: string): void {
+    if (this.#missingQuoteAuthorizationReferenceMethods.has(method)) return;
+    this.#missingQuoteAuthorizationReferenceMethods.add(method);
+    logger.warn(
+      "Repository does not implement {method}; quote-authorization revocation and cleanup are disabled for this repository.",
+      { method },
+    );
   }
 
   async setKeyPairs(
@@ -2460,7 +2474,12 @@ export class MigrationGatedRepository implements Repository {
     if (
       typeof this.#repository.findQuoteAuthorizationReferenceIdentifiers !==
         "function"
-    ) return;
+    ) {
+      this.#warnMissingQuoteAuthorizationReferenceMethod(
+        "findQuoteAuthorizationReferenceIdentifiers",
+      );
+      return;
+    }
     yield* this.#repository.findQuoteAuthorizationReferenceIdentifiers(
       authorization,
     );
@@ -2474,7 +2493,12 @@ export class MigrationGatedRepository implements Repository {
     if (
       typeof this.#repository.findQuoteAuthorizationReferenceAttribution !==
         "function"
-    ) return undefined;
+    ) {
+      this.#warnMissingQuoteAuthorizationReferenceMethod(
+        "findQuoteAuthorizationReferenceAttribution",
+      );
+      return undefined;
+    }
     return await this.#repository.findQuoteAuthorizationReferenceAttribution(
       identifier,
       authorization,

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -879,7 +879,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       object,
     );
     if (actor == null) return;
-    await this.#forwardQuoteAuthorizationDeletion(ctx, object);
+    await this.#forwardQuoteAuthorizationDeletion(ctx, object, actor);
     const stripped = await this.#stripRejectedQuote(ctx, id, object, actor);
     if (stripped != null && this.onQuoteRevoked != null) {
       await this.onQuoteRevoked(stripped.session, stripped.message, actor);
@@ -1041,16 +1041,76 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
   async #forwardQuoteAuthorizationDeletion(
     ctx: InboxContext<TContextData>,
     object: MessageClass,
+    quoteActor: Actor,
   ): Promise<void> {
     const visibility = await this.#getMessageVisibility(ctx, object);
-    if (
-      visibility !== "public" && visibility !== "unlisted" &&
-      visibility !== "followers"
-    ) return;
-    await ctx.forwardActivity(this, "followers", {
+    const preferSharedInbox = visibility === "public" ||
+      visibility === "unlisted" || visibility === "followers";
+    const excludeBaseUris = [new URL(ctx.origin)];
+    const followersUri = ctx.getFollowersUri(this.identifier);
+    const botActorUri = ctx.getActorUri(this.identifier);
+    const recipientIds = new Map<string, URL>();
+    let forwardsToFollowers = false;
+    const addRecipientId = (id: URL | null | undefined) => {
+      if (id == null) return;
+      if (id.href === followersUri.href) {
+        forwardsToFollowers = true;
+        return;
+      }
+      if (
+        id.href === PUBLIC_COLLECTION.href ||
+        id.href === botActorUri.href
+      ) {
+        return;
+      }
+      recipientIds.set(id.href, id);
+    };
+    for (const id of object.toIds) addRecipientId(id);
+    for (const id of object.ccIds) addRecipientId(id);
+    for await (
+      const tag of object.getTags({
+        contextLoader: ctx.contextLoader,
+        documentLoader: ctx.documentLoader,
+        suppressError: true,
+      })
+    ) {
+      if (tag instanceof Mention) addRecipientId(tag.href);
+    }
+    if (forwardsToFollowers) {
+      await ctx.forwardActivity(this, "followers", {
+        skipIfUnsigned: true,
+        preferSharedInbox: true,
+        excludeBaseUris,
+      });
+    }
+    const actorRecipients: Actor[] = [];
+    const actorRecipientIds = new Set<string>();
+    const knownActors = new Map<string, Actor>();
+    if (quoteActor.id != null) knownActors.set(quoteActor.id.href, quoteActor);
+    const addActorRecipient = (actor: Actor) => {
+      if (
+        actor.id == null ||
+        actor.id.href === botActorUri.href ||
+        actorRecipientIds.has(actor.id.href)
+      ) return;
+      actorRecipientIds.add(actor.id.href);
+      actorRecipients.push(actor);
+    };
+    for (const id of recipientIds.values()) {
+      const knownActor = knownActors.get(id.href);
+      if (knownActor != null) {
+        addActorRecipient(knownActor);
+        continue;
+      }
+      const recipient = await lookupObjectSafely(this, ctx, id);
+      if (isActor(recipient)) addActorRecipient(recipient);
+    }
+    addActorRecipient(quoteActor);
+    if (actorRecipients.length < 1) return;
+    await ctx.forwardActivity(this, actorRecipients, {
       skipIfUnsigned: true,
-      preferSharedInbox: true,
-      excludeBaseUris: [new URL(ctx.origin)],
+      preferSharedInbox,
+      excludeBaseUris,
     });
   }
 

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -1096,14 +1096,31 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       actorRecipientIds.add(actor.id.href);
       actorRecipients.push(actor);
     };
-    for (const id of recipientIds.values()) {
-      const knownActor = knownActors.get(id.href);
-      if (knownActor != null) {
-        addActorRecipient(knownActor);
-        continue;
+    const resolvedRecipients = await Promise.all(
+      Array.from(recipientIds.values(), async (id) => {
+        const knownActor = knownActors.get(id.href);
+        if (knownActor != null) return knownActor;
+        const recipient = await lookupObjectSafely(this, ctx, id);
+        return isActor(recipient) ? recipient : undefined;
+      }),
+    );
+    for (const recipient of resolvedRecipients) {
+      if (recipient != null) addActorRecipient(recipient);
+    }
+    if (object.replyTargetId != null) {
+      const replyTarget = await lookupObjectSafely(
+        this,
+        ctx,
+        object.replyTargetId,
+      );
+      if (isMessageObject(replyTarget)) {
+        const replyActor = await replyTarget.getAttribution({
+          contextLoader: ctx.contextLoader,
+          documentLoader: ctx.documentLoader,
+          suppressError: true,
+        });
+        if (isActor(replyActor)) addActorRecipient(replyActor);
       }
-      const recipient = await lookupObjectSafely(this, ctx, id);
-      if (isActor(recipient)) addActorRecipient(recipient);
     }
     addActorRecipient(quoteActor);
     if (actorRecipients.length < 1) return;

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -1700,8 +1700,11 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       // @ts-ignore: quoteTarget.class satisfies (typeof messageClasses)[number]
       messageClasses.includes(quoteTarget.class) &&
       quoteTarget.values.identifier === this.identifier;
-    if (requiresQuoteAuthorization && isLocalQuoteTarget) {
-      await this.#hasValidQuoteAuthorization(ctx, object, fepQuoteUrl);
+    if (
+      requiresQuoteAuthorization && isLocalQuoteTarget &&
+      !await this.#hasValidQuoteAuthorization(ctx, object, fepQuoteUrl)
+    ) {
+      return;
     }
     if (
       this.onQuote != null &&
@@ -2454,6 +2457,10 @@ export class MigrationGatedRepository implements Repository {
     authorization: URL,
   ): AsyncIterable<string> {
     await this.#migration;
+    if (
+      typeof this.#repository.findQuoteAuthorizationReferenceIdentifiers !==
+        "function"
+    ) return;
     yield* this.#repository.findQuoteAuthorizationReferenceIdentifiers(
       authorization,
     );
@@ -2464,6 +2471,10 @@ export class MigrationGatedRepository implements Repository {
     authorization: URL,
   ): Promise<URL | undefined> {
     await this.#migration;
+    if (
+      typeof this.#repository.findQuoteAuthorizationReferenceAttribution !==
+        "function"
+    ) return undefined;
     return await this.#repository.findQuoteAuthorizationReferenceAttribution(
       identifier,
       authorization,

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -841,7 +841,13 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     }
     const rejecter = await this.#validateQuoteRejection(ctx, reject, object);
     if (rejecter == null) return;
-    const stripped = await this.#stripRejectedQuote(ctx, id, object, rejecter);
+    const stripped = await this.#stripRejectedQuote(
+      ctx,
+      id,
+      object,
+      rejecter,
+      this.onQuoteRejected != null,
+    );
     if (stripped != null && this.onQuoteRejected != null) {
       await this.onQuoteRejected(
         stripped.session,
@@ -880,7 +886,13 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     );
     if (actor == null) return;
     await this.#forwardQuoteAuthorizationDeletion(ctx, object, actor);
-    const stripped = await this.#stripRejectedQuote(ctx, id, object, actor);
+    const stripped = await this.#stripRejectedQuote(
+      ctx,
+      id,
+      object,
+      actor,
+      this.onQuoteRevoked != null,
+    );
     if (stripped != null && this.onQuoteRevoked != null) {
       await this.onQuoteRevoked(stripped.session, stripped.message, actor);
     }
@@ -891,6 +903,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     id: Uuid,
     object: MessageClass,
     actor: Actor,
+    materializeMessage: boolean,
   ): Promise<
     | {
       readonly session: SessionImpl<TContextData>;
@@ -928,6 +941,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     }
     if (!wasUpdated || strippedObject == null) return;
     await this.#sendQuoteUpdate(ctx, strippedObject, actor);
+    if (!materializeMessage) return;
     const session = this.getSession(ctx);
     const message = await createMessage(
       strippedObject,

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -81,6 +81,7 @@ import type {
   QuoteEventHandler,
   QuoteRejectedEventHandler,
   QuoteRequestEventHandler,
+  QuoteRevokedEventHandler,
   ReactionEventHandler,
   RejectEventHandler,
   ReplyEventHandler,
@@ -108,6 +109,7 @@ import type {
   SharedMessage,
 } from "./message.ts";
 import type { Vote } from "./poll.ts";
+import { validateQuoteAuthorization } from "./quote-authorization.ts";
 import { QuoteRequestImpl } from "./quote-impl.ts";
 import { normalizeQuotePolicy, type QuotePolicyOption } from "./quote.ts";
 import type { Like, Reaction } from "./reaction.ts";
@@ -165,6 +167,7 @@ export const botEventHandlerNames = [
   "onQuoteRequest",
   "onQuoteAccepted",
   "onQuoteRejected",
+  "onQuoteRevoked",
   "onMessage",
   "onSharedMessage",
   "onLike",
@@ -240,6 +243,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
   onQuoteRequest?: QuoteRequestEventHandler<TContextData>;
   onQuoteAccepted?: QuoteAcceptedEventHandler<TContextData>;
   onQuoteRejected?: QuoteRejectedEventHandler<TContextData>;
+  onQuoteRevoked?: QuoteRevokedEventHandler<TContextData>;
   onMessage?: MessageEventHandler<TContextData>;
   onSharedMessage?: SharedMessageEventHandler<TContextData>;
   onLike?: LikeEventHandler<TContextData>;
@@ -837,7 +841,14 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     }
     const rejecter = await this.#validateQuoteRejection(ctx, reject, object);
     if (rejecter == null) return;
-    await this.#stripRejectedQuote(ctx, id, object, rejecter);
+    const stripped = await this.#stripRejectedQuote(ctx, id, object, rejecter);
+    if (stripped != null && this.onQuoteRejected != null) {
+      await this.onQuoteRejected(
+        stripped.session,
+        stripped.message,
+        rejecter,
+      );
+    }
   }
 
   async onDeleted(
@@ -868,7 +879,15 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       object,
     );
     if (actor == null) return;
-    await this.#stripRejectedQuote(ctx, id, object, actor);
+    await ctx.forwardActivity(this, "followers", {
+      skipIfUnsigned: true,
+      preferSharedInbox: true,
+      excludeBaseUris: [new URL(ctx.origin)],
+    });
+    const stripped = await this.#stripRejectedQuote(ctx, id, object, actor);
+    if (stripped != null && this.onQuoteRevoked != null) {
+      await this.onQuoteRevoked(stripped.session, stripped.message, actor);
+    }
   }
 
   async #stripRejectedQuote(
@@ -876,7 +895,13 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     id: Uuid,
     object: MessageClass,
     actor: Actor,
-  ): Promise<void> {
+  ): Promise<
+    | {
+      readonly session: SessionImpl<TContextData>;
+      readonly message: AuthorizedMessage<MessageClass, TContextData>;
+    }
+    | undefined
+  > {
     const quoteId = object.quoteId;
     let strippedObject: MessageClass | undefined;
     const wasUpdated = await this.repository.updateMessage(
@@ -903,18 +928,16 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     }
     if (!wasUpdated || strippedObject == null) return;
     await this.#sendQuoteUpdate(ctx, strippedObject, actor);
-    if (this.onQuoteRejected != null) {
-      const session = this.getSession(ctx);
-      const message = await createMessage(
-        strippedObject,
-        session,
-        { [actor.id!.href]: actor },
-        undefined,
-        undefined,
-        true,
-      ) as AuthorizedMessage<MessageClass, TContextData>;
-      await this.onQuoteRejected(session, message, actor);
-    }
+    const session = this.getSession(ctx);
+    const message = await createMessage(
+      strippedObject,
+      session,
+      actor.id == null ? {} : { [actor.id.href]: actor },
+      undefined,
+      undefined,
+      true,
+    ) as AuthorizedMessage<MessageClass, TContextData>;
+    return { session, message };
   }
 
   async #validateQuoteApproval(
@@ -952,13 +975,12 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       authorization = await lookupObjectSafely(this, ctx, accept.resultId);
     }
     if (
-      !(authorization instanceof QuoteAuthorization) ||
-      authorization.id == null ||
-      authorization.id.href !== accept.resultId.href ||
-      authorization.id.origin !== actor.id.origin ||
-      authorization.attributionId?.href !== actor.id.href ||
-      authorization.interactingObjectId?.href !== object.id!.href ||
-      authorization.interactionTargetId?.href !== object.quoteId!.href
+      !validateQuoteAuthorization(authorization, {
+        authorizationId: accept.resultId,
+        quoteId: object.id!,
+        targetId: object.quoteId!,
+        targetActorId: actor.id,
+      })
     ) return undefined;
     return { actor, authorization };
   }
@@ -1005,11 +1027,9 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     ) {
       return undefined;
     }
-    const attribution = await this.repository
-      .findQuoteAuthorizationReferenceAttribution(
-        object.quoteAuthorizationId,
-      );
-    if (attribution?.href !== actor.id.href) return undefined;
+    if (actor.id.origin !== object.quoteAuthorizationId.origin) {
+      return undefined;
+    }
     return actor;
   }
 
@@ -1403,10 +1423,12 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       parsed.values.id as Uuid,
     );
     if (
-      authorization?.attributionId?.href !==
-        ctx.getActorUri(this.identifier).href ||
-      authorization.interactingObjectId?.href !== object.id.href ||
-      authorization.interactionTargetId?.href !== targetId.href
+      !validateQuoteAuthorization(authorization, {
+        authorizationId: object.quoteAuthorizationId,
+        quoteId: object.id,
+        targetId,
+        targetActorId: ctx.getActorUri(this.identifier),
+      })
     ) {
       return false;
     }
@@ -1661,16 +1683,12 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       // @ts-ignore: quoteTarget.class satisfies (typeof messageClasses)[number]
       messageClasses.includes(quoteTarget.class) &&
       quoteTarget.values.identifier === this.identifier;
-    const hasValidQuoteAuthorization = !requiresQuoteAuthorization ||
-      (fepQuoteUrl != null && isLocalQuoteTarget &&
-        await this.#hasValidQuoteAuthorization(ctx, object, fepQuoteUrl));
     if (requiresQuoteAuthorization && isLocalQuoteTarget) {
-      if (!hasValidQuoteAuthorization) return;
+      await this.#hasValidQuoteAuthorization(ctx, object, fepQuoteUrl);
     }
     if (
       this.onQuote != null &&
-      isLocalQuoteTarget &&
-      hasValidQuoteAuthorization
+      isLocalQuoteTarget
     ) {
       const message = await getMessage();
       if (
@@ -2121,6 +2139,12 @@ export function wrapBotImpl<TContextData>(
     set onQuoteRejected(value) {
       bot.onQuoteRejected = value;
     },
+    get onQuoteRevoked() {
+      return bot.onQuoteRevoked;
+    },
+    set onQuoteRevoked(value) {
+      bot.onQuoteRevoked = value;
+    },
     get onMessage() {
       return bot.onMessage;
     },
@@ -2409,6 +2433,15 @@ export class MigrationGatedRepository implements Repository {
     );
   }
 
+  async *findQuoteAuthorizationReferenceIdentifiers(
+    authorization: URL,
+  ): AsyncIterable<string> {
+    await this.#migration;
+    yield* this.#repository.findQuoteAuthorizationReferenceIdentifiers(
+      authorization,
+    );
+  }
+
   async findQuoteAuthorizationReferenceAttribution(
     identifier: string,
     authorization: URL,
@@ -2487,6 +2520,7 @@ export class BotGroupImpl<TContextData> implements BotGroup<TContextData> {
   onQuoteRequest?: QuoteRequestEventHandler<TContextData>;
   onQuoteAccepted?: QuoteAcceptedEventHandler<TContextData>;
   onQuoteRejected?: QuoteRejectedEventHandler<TContextData>;
+  onQuoteRevoked?: QuoteRevokedEventHandler<TContextData>;
   onMessage?: MessageEventHandler<TContextData>;
   onSharedMessage?: SharedMessageEventHandler<TContextData>;
   onLike?: LikeEventHandler<TContextData>;

--- a/packages/botkit/src/bot-impl.ts
+++ b/packages/botkit/src/bot-impl.ts
@@ -879,11 +879,7 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
       object,
     );
     if (actor == null) return;
-    await ctx.forwardActivity(this, "followers", {
-      skipIfUnsigned: true,
-      preferSharedInbox: true,
-      excludeBaseUris: [new URL(ctx.origin)],
-    });
+    await this.#forwardQuoteAuthorizationDeletion(ctx, object);
     const stripped = await this.#stripRejectedQuote(ctx, id, object, actor);
     if (stripped != null && this.onQuoteRevoked != null) {
       await this.onQuoteRevoked(stripped.session, stripped.message, actor);
@@ -1030,7 +1026,28 @@ export class BotImpl<TContextData> implements Bot<TContextData> {
     if (actor.id.origin !== object.quoteAuthorizationId.origin) {
       return undefined;
     }
+    const attribution = await this.repository
+      .findQuoteAuthorizationReferenceAttribution(
+        object.quoteAuthorizationId,
+      );
+    if (attribution?.href !== actor.id.href) return undefined;
     return actor;
+  }
+
+  async #forwardQuoteAuthorizationDeletion(
+    ctx: InboxContext<TContextData>,
+    object: MessageClass,
+  ): Promise<void> {
+    const visibility = await this.#getMessageVisibility(ctx, object);
+    if (
+      visibility !== "public" && visibility !== "unlisted" &&
+      visibility !== "followers"
+    ) return;
+    await ctx.forwardActivity(this, "followers", {
+      skipIfUnsigned: true,
+      preferSharedInbox: true,
+      excludeBaseUris: [new URL(ctx.origin)],
+    });
   }
 
   async #sendQuoteUpdate(

--- a/packages/botkit/src/bot.test.ts
+++ b/packages/botkit/src/bot.test.ts
@@ -86,6 +86,15 @@ test("createBot()", async () => {
   assert.strictEqual(bot.onQuoteRejected, onQuoteRejected);
   assert.strictEqual(impl.onQuoteRejected, onQuoteRejected);
 
+  function onQuoteRevoked(
+    _session: Session<void>,
+    _message: AuthorizedMessage<MessageClass, void>,
+    _revoker: Actor,
+  ) {}
+  bot.onQuoteRevoked = onQuoteRevoked;
+  assert.strictEqual(bot.onQuoteRevoked, onQuoteRevoked);
+  assert.strictEqual(impl.onQuoteRevoked, onQuoteRevoked);
+
   function onMention(
     _session: Session<void>,
     _message: Message<MessageClass, void>,

--- a/packages/botkit/src/bot.ts
+++ b/packages/botkit/src/bot.ts
@@ -33,6 +33,7 @@ import type {
   QuoteEventHandler,
   QuoteRejectedEventHandler,
   QuoteRequestEventHandler,
+  QuoteRevokedEventHandler,
   ReactionEventHandler,
   RejectEventHandler,
   ReplyEventHandler,
@@ -109,6 +110,13 @@ export interface BotEventHandlers<TContextData> {
    * @since 0.5.0
    */
   onQuoteRejected?: QuoteRejectedEventHandler<TContextData>;
+
+  /**
+   * An event handler invoked when a quote authorization for the bot's quote
+   * post is revoked.
+   * @since 0.5.0
+   */
+  onQuoteRevoked?: QuoteRevokedEventHandler<TContextData>;
 
   /**
    * An event handler for a message shown to the bot's timeline.  To listen

--- a/packages/botkit/src/events.ts
+++ b/packages/botkit/src/events.ts
@@ -145,6 +145,21 @@ export type QuoteRejectedEventHandler<TContextData> = (
 ) => void | Promise<void>;
 
 /**
+ * An event handler invoked when an authorization stamp for the bot's quote
+ * post is revoked.
+ * @typeParam TContextData The type of the context data.
+ * @param session The session of the bot.
+ * @param message The bot's quote message after the quote target was removed.
+ * @param revoker The actor who revoked the quote authorization stamp.
+ * @since 0.5.0
+ */
+export type QuoteRevokedEventHandler<TContextData> = (
+  session: Session<TContextData>,
+  message: AuthorizedMessage<MessageClass, TContextData>,
+  revoker: Actor,
+) => void | Promise<void>;
+
+/**
  * An event handler for a message shown to the bot's timeline.  To listen to
  * this event, your bot needs to follow others first.
  * @typeParam TContextData The type of the context data.

--- a/packages/botkit/src/helpers.ts
+++ b/packages/botkit/src/helpers.ts
@@ -1,0 +1,29 @@
+// BotKit by Fedify: A framework for creating ActivityPub bots
+// Copyright (C) 2025–2026 Hong Minhee <https://hongminhee.org/>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import type { Repository } from "./repository.ts";
+
+export function hideRepositoryMethods(
+  repository: Repository,
+  hiddenMethods: readonly PropertyKey[],
+): Repository {
+  return new Proxy(repository, {
+    get(target, prop, receiver) {
+      if (hiddenMethods.includes(prop)) return undefined;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}

--- a/packages/botkit/src/instance-impl.ts
+++ b/packages/botkit/src/instance-impl.ts
@@ -680,12 +680,20 @@ export class InstanceImpl<TContextData>
     ctx: InboxContext<TContextData>,
     del: Delete,
   ): Promise<void> {
-    const bots = await this.#resolveTargets(ctx, () => {
+    const bots = await this.#resolveTargets(ctx, async () => {
       const targets = new Set<string>();
       for (const uri of [...del.toIds, ...del.ccIds]) {
         const parsed = ctx.parseUri(uri);
         if (parsed?.type === "actor" || parsed?.type === "followers") {
           if (parsed.identifier != null) targets.add(parsed.identifier);
+        }
+      }
+      if (del.objectId != null) {
+        for await (
+          const identifier of this.repository
+            .findQuoteAuthorizationReferenceIdentifiers(del.objectId)
+        ) {
+          targets.add(identifier);
         }
       }
       return targets;

--- a/packages/botkit/src/instance-impl.ts
+++ b/packages/botkit/src/instance-impl.ts
@@ -688,7 +688,11 @@ export class InstanceImpl<TContextData>
           if (parsed.identifier != null) targets.add(parsed.identifier);
         }
       }
-      if (del.objectId != null) {
+      if (
+        del.objectId != null &&
+        typeof this.repository.findQuoteAuthorizationReferenceIdentifiers ===
+          "function"
+      ) {
         for await (
           const identifier of this.repository
             .findQuoteAuthorizationReferenceIdentifiers(del.objectId)

--- a/packages/botkit/src/instance-routing.test.ts
+++ b/packages/botkit/src/instance-routing.test.ts
@@ -33,7 +33,7 @@ import { describe, test } from "node:test";
 import type { Bot } from "./bot.ts";
 import { BotImpl } from "./bot-impl.ts";
 import { InstanceImpl } from "./instance-impl.ts";
-import { MemoryRepository, type Uuid } from "./repository.ts";
+import { MemoryRepository, type Repository, type Uuid } from "./repository.ts";
 
 function createMockInboxContext<TContextData>(
   instance: InstanceImpl<TContextData>,
@@ -85,6 +85,19 @@ function createHarness(): Harness {
     undefined,
   );
   return { instance, repository, alpha, beta, ctx };
+}
+
+function hideRepositoryMethods(
+  repository: Repository,
+  hiddenMethods: readonly PropertyKey[],
+): Repository {
+  return new Proxy(repository, {
+    get(target, prop, receiver) {
+      if (hiddenMethods.includes(prop)) return undefined;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
 }
 
 function remotePerson(handle: string): Person {
@@ -555,6 +568,33 @@ describe("shared inbox routing", () => {
     assert.ok(object instanceof Note);
     assert.deepStrictEqual(object.quoteAuthorizationId, null);
     assert.deepStrictEqual(object.quoteId, null);
+  });
+
+  test("routes Deletes when quote reference indexes are unsupported", async () => {
+    const repository = hideRepositoryMethods(new MemoryRepository(), [
+      "findQuoteAuthorizationReferenceIdentifiers",
+    ]);
+    const instance = new InstanceImpl<void>({
+      kv: new MemoryKvStore(),
+      repository,
+    });
+    instance.createBot("alpha", { username: "alphabot" });
+    const ctx = createMockInboxContext(
+      instance,
+      "https://example.com/",
+      undefined,
+    );
+
+    await assert.doesNotReject(() =>
+      instance.onDeleted(
+        ctx,
+        new Delete({
+          actor: remotePerson("john"),
+          object: new URL("https://remote.example/stamps/1"),
+          to: new URL("https://example.com/ap/actor/alpha"),
+        }),
+      )
+    );
   });
 
   test("routes dynamic bot quote authorization Deletes by reference index", async () => {

--- a/packages/botkit/src/instance-routing.test.ts
+++ b/packages/botkit/src/instance-routing.test.ts
@@ -33,7 +33,8 @@ import { describe, test } from "node:test";
 import type { Bot } from "./bot.ts";
 import { BotImpl } from "./bot-impl.ts";
 import { InstanceImpl } from "./instance-impl.ts";
-import { MemoryRepository, type Repository, type Uuid } from "./repository.ts";
+import { MemoryRepository, type Uuid } from "./repository.ts";
+import { hideRepositoryMethods } from "./helpers.ts";
 
 function createMockInboxContext<TContextData>(
   instance: InstanceImpl<TContextData>,
@@ -85,19 +86,6 @@ function createHarness(): Harness {
     undefined,
   );
   return { instance, repository, alpha, beta, ctx };
-}
-
-function hideRepositoryMethods(
-  repository: Repository,
-  hiddenMethods: readonly PropertyKey[],
-): Repository {
-  return new Proxy(repository, {
-    get(target, prop, receiver) {
-      if (hiddenMethods.includes(prop)) return undefined;
-      const value = Reflect.get(target, prop, receiver);
-      return typeof value === "function" ? value.bind(target) : value;
-    },
-  });
 }
 
 function remotePerson(handle: string): Person {

--- a/packages/botkit/src/instance-routing.test.ts
+++ b/packages/botkit/src/instance-routing.test.ts
@@ -480,13 +480,13 @@ describe("shared inbox routing", () => {
     assert.deepStrictEqual(events, ["quote:alpha"]);
   });
 
-  test("routes quote authorization Deletes to addressed bots", async () => {
+  test("routes quote authorization Deletes by reference index", async () => {
     const { instance, repository, alpha, beta, ctx } = createHarness();
     const events: string[] = [];
-    alpha.onQuoteRejected = (session) =>
-      void (events.push(`rejected:${session.bot.identifier}`));
-    beta.onQuoteRejected = (session) =>
-      void (events.push(`rejected:${session.bot.identifier}`));
+    alpha.onQuoteRevoked = (session) =>
+      void (events.push(`revoked:${session.bot.identifier}`));
+    beta.onQuoteRevoked = (session) =>
+      void (events.push(`revoked:${session.bot.identifier}`));
     const author = new Person({
       id: new URL("https://remote.example/actors/john"),
       preferredUsername: "john",
@@ -541,11 +541,10 @@ describe("shared inbox routing", () => {
       new Delete({
         actor: author,
         object: authorization,
-        to: new URL("https://example.com/ap/actor/alpha"),
       }),
     );
 
-    assert.deepStrictEqual(events, ["rejected:alpha"]);
+    assert.deepStrictEqual(events, ["revoked:alpha"]);
     assert.deepStrictEqual(
       await repository.findQuoteAuthorizationReference("alpha", authorization),
       undefined,
@@ -556,6 +555,89 @@ describe("shared inbox routing", () => {
     assert.ok(object instanceof Note);
     assert.deepStrictEqual(object.quoteAuthorizationId, null);
     assert.deepStrictEqual(object.quoteId, null);
+  });
+
+  test("routes dynamic bot quote authorization Deletes by reference index", async () => {
+    const repository = new MemoryRepository();
+    const instance = new InstanceImpl<void>({
+      kv: new MemoryKvStore(),
+      repository,
+    });
+    const group = instance.createBot((_ctx, identifier) =>
+      identifier.startsWith("region_") ? { username: identifier } : null
+    );
+    const ctx = createMockInboxContext(
+      instance,
+      "https://example.com/",
+      undefined,
+    );
+    const events: string[] = [];
+    group.onQuoteRevoked = (session) =>
+      void (events.push(`revoked:${session.bot.identifier}`));
+    const author = new Person({
+      id: new URL("https://remote.example/actors/john"),
+      preferredUsername: "john",
+    });
+    const target = new Note({
+      id: new URL("https://remote.example/notes/original"),
+      attribution: author,
+      content: "Original.",
+      to: PUBLIC_COLLECTION,
+    });
+    Object.defineProperty(ctx, "lookupObject", {
+      value: (id: URL) =>
+        Promise.resolve(id.href === target.id?.href ? target : null),
+      configurable: true,
+    });
+    const messageId = "01950000-0000-7000-8000-000000000306" as Uuid;
+    const authorization = new URL("https://remote.example/stamps/2");
+    await repository.addMessage(
+      "region_kr",
+      messageId,
+      new Create({
+        id: new URL(
+          `https://example.com/ap/actor/region_kr/create/${messageId}`,
+        ),
+        actor: new URL("https://example.com/ap/actor/region_kr"),
+        to: PUBLIC_COLLECTION,
+        object: new Note({
+          id: new URL(
+            `https://example.com/ap/actor/region_kr/note/${messageId}`,
+          ),
+          attribution: new URL("https://example.com/ap/actor/region_kr"),
+          to: PUBLIC_COLLECTION,
+          content: `<p>Quote.</p>\n\n<p class="quote-inline"><br>RE: <a href="${
+            target.id!.href
+          }">${target.id!.href}</a></p>`,
+          quote: target.id,
+          quoteUrl: target.id,
+          quoteAuthorization: authorization,
+        }),
+      }),
+    );
+    await repository.addQuoteAuthorizationReference(
+      "region_kr",
+      authorization,
+      messageId,
+      author.id!,
+    );
+
+    await instance.onDeleted(
+      ctx,
+      new Delete({
+        actor: author,
+        object: authorization,
+      }),
+    );
+
+    assert.deepStrictEqual(events, ["revoked:region_kr"]);
+    assert.deepStrictEqual(
+      await repository.findQuoteAuthorizationReference(
+        "region_kr",
+        authorization,
+      ),
+      undefined,
+    );
   });
 
   test("routes Create to followers of the author", async () => {

--- a/packages/botkit/src/message-impl.test.ts
+++ b/packages/botkit/src/message-impl.test.ts
@@ -218,12 +218,20 @@ test("createMessage() verifies quote approvals", async (t) => {
       readonly quoteAuthorization?: URL;
       readonly authorization?: QuoteAuthorization | null;
       readonly throwOnAuthorization?: boolean;
+      readonly signal?: AbortSignal;
+      readonly onAuthorizationLookup?: (
+        options: Parameters<typeof ctx.lookupObject>[1],
+      ) => void;
     } = {},
   ) => {
     Object.defineProperty(ctx, "lookupObject", {
-      value: (id: URL) => {
+      value: (
+        id: URL,
+        lookupOptions?: Parameters<typeof ctx.lookupObject>[1],
+      ) => {
         if (id.href === targetId.href) return Promise.resolve(target);
         if (id.href === authorizationId.href) {
+          options.onAuthorizationLookup?.(lookupOptions);
           if (options.throwOnAuthorization === true) {
             return Promise.reject(new TypeError("Fetch failed."));
           }
@@ -245,6 +253,10 @@ test("createMessage() verifies quote approvals", async (t) => {
       }),
       session,
       {},
+      undefined,
+      undefined,
+      undefined,
+      options.signal,
     );
   };
 
@@ -345,6 +357,27 @@ test("createMessage() verifies quote approvals", async (t) => {
       throwOnAuthorization: true,
     });
     assert.deepStrictEqual(message.quoteApproved, false);
+  });
+
+  await t.test("passes abort signal to remote stamp lookup", async () => {
+    const controller = new AbortController();
+    let lookupSignal: AbortSignal | undefined;
+    const message = await materialize({
+      quote: targetId,
+      quoteAuthorization: authorizationId,
+      authorization: new QuoteAuthorization({
+        id: authorizationId,
+        attribution: author.id,
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+      signal: controller.signal,
+      onAuthorizationLookup: (options) => {
+        lookupSignal = options?.signal;
+      },
+    });
+    assert.deepStrictEqual(message.quoteApproved, true);
+    assert.deepStrictEqual(lookupSignal, controller.signal);
   });
 
   await t.test("legacy quote", async () => {

--- a/packages/botkit/src/message-impl.test.ts
+++ b/packages/botkit/src/message-impl.test.ts
@@ -217,6 +217,7 @@ test("createMessage() verifies quote approvals", async (t) => {
       readonly quoteUrl?: URL;
       readonly quoteAuthorization?: URL;
       readonly authorization?: QuoteAuthorization | null;
+      readonly authorizationError?: unknown;
       readonly throwOnAuthorization?: boolean;
       readonly signal?: AbortSignal;
       readonly onAuthorizationLookup?: (
@@ -232,6 +233,9 @@ test("createMessage() verifies quote approvals", async (t) => {
         if (id.href === targetId.href) return Promise.resolve(target);
         if (id.href === authorizationId.href) {
           options.onAuthorizationLookup?.(lookupOptions);
+          if (options.authorizationError != null) {
+            return Promise.reject(options.authorizationError);
+          }
           if (options.throwOnAuthorization === true) {
             return Promise.reject(new TypeError("Fetch failed."));
           }
@@ -378,6 +382,22 @@ test("createMessage() verifies quote approvals", async (t) => {
     });
     assert.deepStrictEqual(message.quoteApproved, true);
     assert.deepStrictEqual(lookupSignal, controller.signal);
+  });
+
+  await t.test("preserves abort errors from remote stamp lookup", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("Aborted.", "AbortError");
+    controller.abort(reason);
+    await assert.rejects(
+      () =>
+        materialize({
+          quote: targetId,
+          quoteAuthorization: authorizationId,
+          authorizationError: reason,
+          signal: controller.signal,
+        }),
+      (error) => error === reason,
+    );
   });
 
   await t.test("legacy quote", async () => {

--- a/packages/botkit/src/message-impl.test.ts
+++ b/packages/botkit/src/message-impl.test.ts
@@ -30,6 +30,7 @@ import {
   Person,
   PUBLIC_COLLECTION,
   Question,
+  QuoteAuthorization,
   Tombstone,
   Undo,
   Update,
@@ -185,6 +186,173 @@ test("createMessage()", async () => {
   });
   const unknownMessage = await createMessage<Note, void>(unknown, session, {});
   assert.deepStrictEqual(unknownMessage.visibility, "unknown");
+});
+
+test("createMessage() verifies quote approvals", async (t) => {
+  const bot = new BotImpl<void>({ kv: new MemoryKvStore(), username: "bot" });
+  const ctx = createMockContext(bot, "https://example.com");
+  const session = new SessionImpl(bot, ctx);
+  const author = new Person({
+    id: new URL("https://author.example/users/alice"),
+    preferredUsername: "alice",
+  });
+  const quoter = new Person({
+    id: new URL("https://quote.example/users/bob"),
+    preferredUsername: "bob",
+  });
+  const targetId = new URL("https://author.example/notes/original");
+  const quoteId = new URL("https://quote.example/notes/quote");
+  const authorizationId = new URL("https://author.example/stamps/1");
+  const target = new Note({
+    id: targetId,
+    attribution: author,
+    content: "Original.",
+    to: PUBLIC_COLLECTION,
+  });
+
+  const materialize = async (
+    options: {
+      readonly attribution?: Person;
+      readonly quote?: URL;
+      readonly quoteUrl?: URL;
+      readonly quoteAuthorization?: URL;
+      readonly authorization?: QuoteAuthorization | null;
+      readonly throwOnAuthorization?: boolean;
+    } = {},
+  ) => {
+    Object.defineProperty(ctx, "lookupObject", {
+      value: (id: URL) => {
+        if (id.href === targetId.href) return Promise.resolve(target);
+        if (id.href === authorizationId.href) {
+          if (options.throwOnAuthorization === true) {
+            return Promise.reject(new TypeError("Fetch failed."));
+          }
+          return Promise.resolve(options.authorization ?? null);
+        }
+        return Promise.resolve(null);
+      },
+      configurable: true,
+    });
+    return await createMessage<Note, void>(
+      new Note({
+        id: quoteId,
+        attribution: options.attribution ?? quoter,
+        content: "Quote.",
+        to: PUBLIC_COLLECTION,
+        quote: options.quote,
+        quoteUrl: options.quoteUrl,
+        quoteAuthorization: options.quoteAuthorization,
+      }),
+      session,
+      {},
+    );
+  };
+
+  const noQuote = await createMessage<Note, void>(
+    new Note({
+      id: new URL("https://quote.example/notes/plain"),
+      attribution: quoter,
+      content: "Plain.",
+      to: PUBLIC_COLLECTION,
+    }),
+    session,
+    {},
+  );
+  assert.deepStrictEqual(noQuote.quoteApproved, undefined);
+
+  await t.test("self-quote", async () => {
+    const message = await materialize({
+      attribution: author,
+      quote: targetId,
+    });
+    assert.deepStrictEqual(message.quoteApproved, true);
+  });
+
+  await t.test("valid stamp", async () => {
+    const message = await materialize({
+      quote: targetId,
+      quoteAuthorization: authorizationId,
+      authorization: new QuoteAuthorization({
+        id: authorizationId,
+        attribution: author.id,
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+    });
+    assert.deepStrictEqual(message.quoteApproved, true);
+  });
+
+  await t.test("wrong attributedTo", async () => {
+    const message = await materialize({
+      quote: targetId,
+      quoteAuthorization: authorizationId,
+      authorization: new QuoteAuthorization({
+        id: authorizationId,
+        attribution: quoter.id,
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+    });
+    assert.deepStrictEqual(message.quoteApproved, false);
+  });
+
+  await t.test("wrong interactingObject", async () => {
+    const message = await materialize({
+      quote: targetId,
+      quoteAuthorization: authorizationId,
+      authorization: new QuoteAuthorization({
+        id: authorizationId,
+        attribution: author.id,
+        interactingObject: new URL("https://quote.example/notes/other"),
+        interactionTarget: targetId,
+      }),
+    });
+    assert.deepStrictEqual(message.quoteApproved, false);
+  });
+
+  await t.test("wrong interactionTarget", async () => {
+    const message = await materialize({
+      quote: targetId,
+      quoteAuthorization: authorizationId,
+      authorization: new QuoteAuthorization({
+        id: authorizationId,
+        attribution: author.id,
+        interactingObject: quoteId,
+        interactionTarget: new URL("https://author.example/notes/other"),
+      }),
+    });
+    assert.deepStrictEqual(message.quoteApproved, false);
+  });
+
+  await t.test("cross-origin stamp", async () => {
+    const message = await materialize({
+      quote: targetId,
+      quoteAuthorization: authorizationId,
+      authorization: new QuoteAuthorization({
+        id: new URL("https://other.example/stamps/1"),
+        attribution: author.id,
+        interactingObject: quoteId,
+        interactionTarget: targetId,
+      }),
+    });
+    assert.deepStrictEqual(message.quoteApproved, false);
+  });
+
+  await t.test("fetch failure", async () => {
+    const message = await materialize({
+      quote: targetId,
+      quoteAuthorization: authorizationId,
+      throwOnAuthorization: true,
+    });
+    assert.deepStrictEqual(message.quoteApproved, false);
+  });
+
+  await t.test("legacy quote", async () => {
+    const message = await materialize({
+      quoteUrl: targetId,
+    });
+    assert.deepStrictEqual(message.quoteApproved, false);
+  });
 });
 
 test("AuthorizedMessageImpl.delete()", async () => {

--- a/packages/botkit/src/message-impl.test.ts
+++ b/packages/botkit/src/message-impl.test.ts
@@ -400,6 +400,22 @@ test("createMessage() verifies quote approvals", async (t) => {
     );
   });
 
+  await t.test("preserves custom errors after abort", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const error = new TypeError("Lookup cancelled.");
+    await assert.rejects(
+      () =>
+        materialize({
+          quote: targetId,
+          quoteAuthorization: authorizationId,
+          authorizationError: error,
+          signal: controller.signal,
+        }),
+      (actual) => actual === error,
+    );
+  });
+
   await t.test("legacy quote", async () => {
     const message = await materialize({
       quoteUrl: targetId,

--- a/packages/botkit/src/message-impl.ts
+++ b/packages/botkit/src/message-impl.ts
@@ -1020,13 +1020,7 @@ async function verifyQuoteApproval<TContextData>(
       targetActorId: quoteTarget.actor.id,
     });
   } catch (error) {
-    if (
-      signal?.aborted === true &&
-      (error === signal.reason ||
-        (error instanceof DOMException && error.name === "AbortError"))
-    ) {
-      throw error;
-    }
+    if (signal?.aborted === true) throw error;
     return false;
   }
 }

--- a/packages/botkit/src/message-impl.ts
+++ b/packages/botkit/src/message-impl.ts
@@ -1019,7 +1019,14 @@ async function verifyQuoteApproval<TContextData>(
       targetId: quoteTarget.id,
       targetActorId: quoteTarget.actor.id,
     });
-  } catch {
+  } catch (error) {
+    if (
+      signal?.aborted === true &&
+      (error === signal.reason ||
+        (error instanceof DOMException && error.name === "AbortError"))
+    ) {
+      throw error;
+    }
     return false;
   }
 }

--- a/packages/botkit/src/message-impl.ts
+++ b/packages/botkit/src/message-impl.ts
@@ -54,6 +54,7 @@ import type {
 } from "./message.ts";
 import type { AuthorizedLike, AuthorizedReaction } from "./reaction.ts";
 import type { Uuid } from "./repository.ts";
+import { validateQuoteAuthorization } from "./quote-authorization.ts";
 import {
   parseQuotePolicy,
   type QuotePolicy,
@@ -99,6 +100,7 @@ export class MessageImpl<T extends MessageClass, TContextData>
   readonly replyTarget?: Message<MessageClass, TContextData> | undefined;
   readonly quoteTarget?: Message<MessageClass, TContextData> | undefined;
   quotePolicy?: QuotePolicy | undefined;
+  readonly quoteApproved?: boolean | undefined;
   mentions: readonly Actor[];
   hashtags: readonly Hashtag[];
   readonly attachments: readonly Document[];
@@ -127,6 +129,7 @@ export class MessageImpl<T extends MessageClass, TContextData>
     this.replyTarget = message.replyTarget;
     this.quoteTarget = message.quoteTarget;
     this.quotePolicy = message.quotePolicy;
+    this.quoteApproved = message.quoteApproved;
     this.mentions = message.mentions;
     this.hashtags = message.hashtags;
     this.attachments = message.attachments;
@@ -906,6 +909,15 @@ export async function createMessage<T extends MessageClass, TContextData>(
       actor.id ?? raw.attributionId!,
       actor.followersId,
     );
+  const quoteApproved = quoteTarget == null ? undefined : actor.id != null &&
+      quoteTarget.actor.id != null &&
+      actor.id.href === quoteTarget.actor.id.href
+    ? true
+    : await verifyQuoteApproval(
+      raw,
+      quoteTarget,
+      session,
+    );
   const quoteApprovalState = !authorized || quoteTarget == null
     ? undefined
     : quoteTarget.actor.id?.href === actor.id?.href
@@ -935,6 +947,7 @@ export async function createMessage<T extends MessageClass, TContextData>(
     replyTarget,
     quoteTarget,
     quotePolicy,
+    quoteApproved,
     quoteApprovalState,
     mentions,
     hashtags,
@@ -942,6 +955,50 @@ export async function createMessage<T extends MessageClass, TContextData>(
     published: raw.published ?? undefined,
     updated: raw.updated ?? undefined,
   });
+}
+
+async function verifyQuoteApproval<TContextData>(
+  raw: MessageClass,
+  quoteTarget: Message<MessageClass, TContextData>,
+  session: SessionImpl<TContextData>,
+): Promise<boolean> {
+  if (
+    raw.id == null ||
+    raw.quoteAuthorizationId == null ||
+    quoteTarget.actor.id == null
+  ) {
+    return false;
+  }
+  try {
+    const parsed = parseLocalUri(
+      session.context,
+      raw.quoteAuthorizationId,
+      session.bot.legacyObjectUrisIdentifier,
+    );
+    const authorization = parsed?.type === "object" &&
+        parsed.class === QuoteAuthorization &&
+        parsed.values.identifier === session.bot.identifier
+      ? await session.bot.repository.getQuoteAuthorization(
+        parsed.values.id as Uuid,
+      )
+      : await session.context.lookupObject(
+        raw.quoteAuthorizationId,
+        {
+          contextLoader: session.context.contextLoader,
+          documentLoader: await session.context.getDocumentLoader(
+            session.bot,
+          ),
+        },
+      );
+    return validateQuoteAuthorization(authorization, {
+      authorizationId: raw.quoteAuthorizationId,
+      quoteId: raw.id,
+      targetId: quoteTarget.id,
+      targetActorId: quoteTarget.actor.id,
+    });
+  } catch {
+    return false;
+  }
 }
 
 export function getMessageVisibility(

--- a/packages/botkit/src/message-impl.ts
+++ b/packages/botkit/src/message-impl.ts
@@ -769,6 +769,7 @@ export async function createMessage<T extends MessageClass, TContextData>(
   replyTarget: Message<MessageClass, TContextData> | undefined,
   quote: Message<MessageClass, TContextData> | undefined,
   authorized: true,
+  signal?: AbortSignal,
 ): Promise<AuthorizedMessage<T, TContextData>>;
 export async function createMessage<T extends MessageClass, TContextData>(
   raw: T,
@@ -777,6 +778,7 @@ export async function createMessage<T extends MessageClass, TContextData>(
   replyTarget?: Message<MessageClass, TContextData>,
   quote?: Message<MessageClass, TContextData>,
   authorized?: boolean,
+  signal?: AbortSignal,
 ): Promise<Message<T, TContextData>>;
 export async function createMessage<T extends MessageClass, TContextData>(
   raw: T,
@@ -785,6 +787,7 @@ export async function createMessage<T extends MessageClass, TContextData>(
   replyTarget?: Message<MessageClass, TContextData>,
   quoteTarget?: Message<MessageClass, TContextData>,
   authorized: boolean = false,
+  signal?: AbortSignal,
 ): Promise<Message<T, TContextData>> {
   if (raw.id == null) throw new TypeError("The raw.id is required.");
   else if (raw.content == null) {
@@ -795,6 +798,7 @@ export async function createMessage<T extends MessageClass, TContextData>(
     contextLoader: session.context.contextLoader,
     documentLoader,
     suppressError: true,
+    signal,
   };
   const rawActor = raw.attributionId?.href === session.actorId?.href
     ? await session.getActor()
@@ -860,7 +864,15 @@ export async function createMessage<T extends MessageClass, TContextData>(
       rt instanceof Article || rt instanceof ChatMessage ||
       rt instanceof Note || rt instanceof Question
     ) {
-      replyTarget = await createMessage(rt, session, cachedObjects);
+      replyTarget = await createMessage(
+        rt,
+        session,
+        cachedObjects,
+        undefined,
+        undefined,
+        undefined,
+        signal,
+      );
     }
   }
   if (quoteTarget == null) {
@@ -899,7 +911,15 @@ export async function createMessage<T extends MessageClass, TContextData>(
       qt instanceof Article || qt instanceof ChatMessage ||
       qt instanceof Note || qt instanceof Question
     ) {
-      quoteTarget = await createMessage(qt, session, cachedObjects);
+      quoteTarget = await createMessage(
+        qt,
+        session,
+        cachedObjects,
+        undefined,
+        undefined,
+        undefined,
+        signal,
+      );
     }
   }
   const quotePolicy = actor.id == null && raw.attributionId == null
@@ -917,6 +937,7 @@ export async function createMessage<T extends MessageClass, TContextData>(
       raw,
       quoteTarget,
       session,
+      signal,
     );
   const quoteApprovalState = !authorized || quoteTarget == null
     ? undefined
@@ -961,6 +982,7 @@ async function verifyQuoteApproval<TContextData>(
   raw: MessageClass,
   quoteTarget: Message<MessageClass, TContextData>,
   session: SessionImpl<TContextData>,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   if (
     raw.id == null ||
@@ -988,6 +1010,7 @@ async function verifyQuoteApproval<TContextData>(
           documentLoader: await session.context.getDocumentLoader(
             session.bot,
           ),
+          signal,
         },
       );
     return validateQuoteAuthorization(authorization, {

--- a/packages/botkit/src/message.ts
+++ b/packages/botkit/src/message.ts
@@ -158,6 +158,13 @@ export interface Message<T extends MessageClass, TContextData> {
   readonly quotePolicy?: QuotePolicy;
 
   /**
+   * Whether this message's quote target has been approved according to
+   * FEP-044f.  It is `undefined` when this message is not a quote.
+   * @since 0.5.0
+   */
+  readonly quoteApproved?: boolean;
+
+  /**
    * The published time of the message.
    */
   readonly published?: Temporal.Instant;

--- a/packages/botkit/src/quote-authorization.test.ts
+++ b/packages/botkit/src/quote-authorization.test.ts
@@ -82,6 +82,13 @@ test("validateQuoteAuthorization() rejects mismatched authorizations", () => {
       createAuthorization(),
       new URL("https://example.com/stamps/2"),
     ],
+    [
+      "origin",
+      createAuthorization({
+        id: new URL("https://malicious.example/stamps/1"),
+      }),
+      new URL("https://malicious.example/stamps/1"),
+    ],
   ];
 
   for (const [name, authorization, expectedAuthorizationId] of cases) {

--- a/packages/botkit/src/quote-authorization.test.ts
+++ b/packages/botkit/src/quote-authorization.test.ts
@@ -1,0 +1,37 @@
+// BotKit by Fedify: A framework for creating ActivityPub bots
+// Copyright (C) 2025-2026 Hong Minhee <https://hongminhee.org/>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { QuoteAuthorization } from "@fedify/vocab";
+import assert from "node:assert";
+import { test } from "node:test";
+import { validateQuoteAuthorization } from "./quote-authorization.ts";
+
+test("validateQuoteAuthorization() rejects missing target actors", () => {
+  const authorization = new QuoteAuthorization({
+    id: new URL("https://example.com/stamps/1"),
+    attribution: new URL("https://example.com/users/alice"),
+    interactingObject: new URL("https://quote.example/notes/1"),
+    interactionTarget: new URL("https://example.com/notes/1"),
+  });
+
+  assert.ok(
+    !validateQuoteAuthorization(authorization, {
+      authorizationId: authorization.id!,
+      quoteId: new URL("https://quote.example/notes/1"),
+      targetId: new URL("https://example.com/notes/1"),
+      targetActorId: null,
+    }),
+  );
+});

--- a/packages/botkit/src/quote-authorization.test.ts
+++ b/packages/botkit/src/quote-authorization.test.ts
@@ -18,19 +18,102 @@ import assert from "node:assert";
 import { test } from "node:test";
 import { validateQuoteAuthorization } from "./quote-authorization.ts";
 
-test("validateQuoteAuthorization() rejects missing target actors", () => {
-  const authorization = new QuoteAuthorization({
-    id: new URL("https://example.com/stamps/1"),
-    attribution: new URL("https://example.com/users/alice"),
-    interactingObject: new URL("https://quote.example/notes/1"),
-    interactionTarget: new URL("https://example.com/notes/1"),
-  });
+const authorizationId = new URL("https://example.com/stamps/1");
+const quoteId = new URL("https://quote.example/notes/1");
+const targetId = new URL("https://example.com/notes/1");
+const targetActorId = new URL("https://example.com/users/alice");
 
+function createAuthorization(
+  values: {
+    readonly id?: URL;
+    readonly attribution?: URL;
+    readonly interactingObject?: URL;
+    readonly interactionTarget?: URL;
+  } = {},
+): QuoteAuthorization {
+  return new QuoteAuthorization({
+    id: values.id ?? authorizationId,
+    attribution: values.attribution ?? targetActorId,
+    interactingObject: values.interactingObject ?? quoteId,
+    interactionTarget: values.interactionTarget ?? targetId,
+  });
+}
+
+test("validateQuoteAuthorization() accepts matching authorization", () => {
   assert.ok(
-    !validateQuoteAuthorization(authorization, {
-      authorizationId: authorization.id!,
-      quoteId: new URL("https://quote.example/notes/1"),
-      targetId: new URL("https://example.com/notes/1"),
+    validateQuoteAuthorization(createAuthorization(), {
+      authorizationId,
+      quoteId,
+      targetId,
+      targetActorId,
+    }),
+  );
+});
+
+test("validateQuoteAuthorization() rejects mismatched authorizations", () => {
+  const cases: readonly [
+    string,
+    QuoteAuthorization,
+    URL | undefined,
+  ][] = [
+    [
+      "attributionId",
+      createAuthorization({
+        attribution: new URL("https://example.com/users/bob"),
+      }),
+      authorizationId,
+    ],
+    [
+      "interactingObjectId",
+      createAuthorization({
+        interactingObject: new URL("https://quote.example/notes/2"),
+      }),
+      authorizationId,
+    ],
+    [
+      "interactionTargetId",
+      createAuthorization({
+        interactionTarget: new URL("https://example.com/notes/2"),
+      }),
+      authorizationId,
+    ],
+    [
+      "authorizationId",
+      createAuthorization(),
+      new URL("https://example.com/stamps/2"),
+    ],
+  ];
+
+  for (const [name, authorization, expectedAuthorizationId] of cases) {
+    assert.ok(
+      !validateQuoteAuthorization(authorization, {
+        authorizationId: expectedAuthorizationId,
+        quoteId,
+        targetId,
+        targetActorId,
+      }),
+      name,
+    );
+  }
+});
+
+test("validateQuoteAuthorization() rejects non-authorization objects", () => {
+  assert.ok(
+    !validateQuoteAuthorization({}, {
+      authorizationId,
+      quoteId,
+      targetId,
+      targetActorId,
+    }),
+  );
+});
+
+test("validateQuoteAuthorization() rejects missing target actors", () => {
+  assert.ok(
+    !validateQuoteAuthorization(createAuthorization(), {
+      authorizationId,
+      quoteId,
+      targetId,
       targetActorId: null,
     }),
   );

--- a/packages/botkit/src/quote-authorization.ts
+++ b/packages/botkit/src/quote-authorization.ts
@@ -15,19 +15,48 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import { QuoteAuthorization } from "@fedify/vocab";
 
+/**
+ * Expected identifiers for validating a quote authorization stamp.
+ *
+ * @since 0.5.0
+ */
 export interface QuoteAuthorizationValidationOptions {
+  /**
+   * The expected quote authorization stamp ID.
+   */
   readonly authorizationId?: URL;
+
+  /**
+   * The ID of the quote object that uses the authorization.
+   */
   readonly quoteId: URL;
+
+  /**
+   * The ID of the quote target object.
+   */
   readonly targetId: URL;
-  readonly targetActorId: URL;
+
+  /**
+   * The actor that owns the quote target object.
+   */
+  readonly targetActorId: URL | null;
 }
 
+/**
+ * Checks whether an object is a matching FEP-044f quote authorization stamp.
+ *
+ * @param authorization The fetched or stored object to validate.
+ * @param options The identifiers the authorization must match.
+ * @returns `true` if the object is a quote authorization for the quote.
+ * @since 0.5.0
+ */
 export function validateQuoteAuthorization(
   authorization: unknown,
   options: QuoteAuthorizationValidationOptions,
 ): authorization is QuoteAuthorization {
   return authorization instanceof QuoteAuthorization &&
     authorization.id != null &&
+    options.targetActorId != null &&
     (options.authorizationId == null ||
       authorization.id.href === options.authorizationId.href) &&
     authorization.id.origin === options.targetActorId.origin &&

--- a/packages/botkit/src/quote-authorization.ts
+++ b/packages/botkit/src/quote-authorization.ts
@@ -1,0 +1,37 @@
+// BotKit by Fedify: A framework for creating ActivityPub bots
+// Copyright (C) 2025–2026 Hong Minhee <https://hongminhee.org/>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { QuoteAuthorization } from "@fedify/vocab";
+
+export interface QuoteAuthorizationValidationOptions {
+  readonly authorizationId?: URL;
+  readonly quoteId: URL;
+  readonly targetId: URL;
+  readonly targetActorId: URL;
+}
+
+export function validateQuoteAuthorization(
+  authorization: unknown,
+  options: QuoteAuthorizationValidationOptions,
+): authorization is QuoteAuthorization {
+  return authorization instanceof QuoteAuthorization &&
+    authorization.id != null &&
+    (options.authorizationId == null ||
+      authorization.id.href === options.authorizationId.href) &&
+    authorization.id.origin === options.targetActorId.origin &&
+    authorization.attributionId?.href === options.targetActorId.href &&
+    authorization.interactingObjectId?.href === options.quoteId.href &&
+    authorization.interactionTargetId?.href === options.targetId.href;
+}

--- a/packages/botkit/src/repository.test.ts
+++ b/packages/botkit/src/repository.test.ts
@@ -2013,6 +2013,7 @@ describe("KvRepository.migrate()", () => {
     followRequestId: URL;
     followeeId: URL;
     followeeFollowJson: unknown;
+    quoteAuthorizationRefId: URL;
     sentFollowId: Uuid;
     sentFollowJson: unknown;
   }> {
@@ -2063,6 +2064,12 @@ describe("KvRepository.migrate()", () => {
     });
     await kv.set(["_botkit", "followees", followeeId.href], followeeFollowJson);
 
+    const quoteAuthorizationRefId = new URL("https://example.com/stamps/1");
+    await kv.set(
+      ["_botkit", "quoteAuthorizationRefs", quoteAuthorizationRefId.href],
+      messageId,
+    );
+
     const sentFollowId: Uuid = "e35ff5d8-ede9-4f5e-9b83-4bfcd4c9a69c";
     const sentFollow = new Follow({
       id: new URL(`https://example.com/ap/follow/${sentFollowId}`),
@@ -2089,6 +2096,7 @@ describe("KvRepository.migrate()", () => {
       followRequestId,
       followeeId,
       followeeFollowJson,
+      quoteAuthorizationRefId,
       sentFollowId,
       sentFollowJson,
     };
@@ -2208,6 +2216,29 @@ describe("KvRepository.migrate()", () => {
     assert.deepStrictEqual(
       await follow?.toJsonLd({ format: "compact" }),
       seed.followeeFollowJson,
+    );
+  });
+
+  test("migrates quote authorization references with their reverse index", async () => {
+    const kv = new MemoryKvStore();
+    const seed = await seedLegacyData(kv);
+    const repo = new KvRepository(kv);
+    await repo.migrate("bot");
+
+    assert.deepStrictEqual(
+      await repo.findQuoteAuthorizationReference(
+        "bot",
+        seed.quoteAuthorizationRefId,
+      ),
+      seed.messageId,
+    );
+    assert.deepStrictEqual(
+      await Array.fromAsync(
+        repo.findQuoteAuthorizationReferenceIdentifiers(
+          seed.quoteAuthorizationRefId,
+        ),
+      ),
+      ["bot"],
     );
   });
 

--- a/packages/botkit/src/repository.test.ts
+++ b/packages/botkit/src/repository.test.ts
@@ -150,8 +150,25 @@ for (const [name, factory] of Object.entries(factories)) {
       undefined,
     );
     assert.deepStrictEqual(
+      await Array.fromAsync(
+        repository.findQuoteAuthorizationReferenceIdentifiers(authorization),
+      ),
+      ["bot"],
+    );
+    assert.deepStrictEqual(
       await repository.findQuoteAuthorizationReference("bot", authorization),
       firstMessageId,
+    );
+    await repository.addQuoteAuthorizationReference(
+      "other",
+      authorization,
+      firstMessageId,
+    );
+    assert.deepStrictEqual(
+      await Array.fromAsync(
+        repository.findQuoteAuthorizationReferenceIdentifiers(authorization),
+      ),
+      ["bot", "other"],
     );
 
     await repository.addQuoteAuthorizationReference(
@@ -170,6 +187,12 @@ for (const [name, factory] of Object.entries(factories)) {
     assert.deepStrictEqual(
       await repository.findQuoteAuthorizationReference("bot", authorization),
       undefined,
+    );
+    assert.deepStrictEqual(
+      await Array.fromAsync(
+        repository.findQuoteAuthorizationReferenceIdentifiers(authorization),
+      ),
+      ["other"],
     );
   });
 }

--- a/packages/botkit/src/repository.test.ts
+++ b/packages/botkit/src/repository.test.ts
@@ -57,6 +57,19 @@ const factories: Record<string, () => Repository> = {
   MemoryCachedRepository: createMemoryCachedRepository,
 };
 
+function hideRepositoryMethods(
+  repository: Repository,
+  hiddenMethods: readonly PropertyKey[],
+): Repository {
+  return new Proxy(repository, {
+    get(target, prop, receiver) {
+      if (hiddenMethods.includes(prop)) return undefined;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
 for (const [name, factory] of Object.entries(factories)) {
   test(`${name} stores quote authorizations`, async () => {
     const repository = factory();
@@ -299,6 +312,42 @@ test("MemoryCachedRepository keeps quote authorization reference cache on remove
   assert.deepStrictEqual(
     await repository.findQuoteAuthorizationReference("bot", authorization),
     messageId,
+  );
+});
+
+test("MemoryCachedRepository tolerates missing quote reference index methods", async () => {
+  const underlying = new MemoryRepository();
+  const authorization = new URL("https://remote.example/stamps/1");
+  const messageId = "01942976-3400-7f34-872e-2cbf0f9eeac4" as Uuid;
+  await underlying.addQuoteAuthorizationReference(
+    "bot",
+    authorization,
+    messageId,
+    new URL("https://remote.example/actors/alice"),
+  );
+  const repository = new MemoryCachedRepository(
+    hideRepositoryMethods(underlying, [
+      "findQuoteAuthorizationReferenceAttribution",
+      "findQuoteAuthorizationReferenceIdentifiers",
+    ]),
+  );
+
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorizationReference("bot", authorization),
+    messageId,
+  );
+  assert.deepStrictEqual(
+    await repository.findQuoteAuthorizationReferenceAttribution(
+      "bot",
+      authorization,
+    ),
+    undefined,
+  );
+  assert.deepStrictEqual(
+    await Array.fromAsync(
+      repository.findQuoteAuthorizationReferenceIdentifiers(authorization),
+    ),
+    [],
   );
 });
 

--- a/packages/botkit/src/repository.test.ts
+++ b/packages/botkit/src/repository.test.ts
@@ -38,6 +38,7 @@ import {
   type Repository,
   type Uuid,
 } from "./repository.ts";
+import { hideRepositoryMethods } from "./helpers.ts";
 
 function createKvRepository(): Repository {
   return new KvRepository(new MemoryKvStore());
@@ -56,19 +57,6 @@ const factories: Record<string, () => Repository> = {
   MemoryRepository: createMemoryRepository,
   MemoryCachedRepository: createMemoryCachedRepository,
 };
-
-function hideRepositoryMethods(
-  repository: Repository,
-  hiddenMethods: readonly PropertyKey[],
-): Repository {
-  return new Proxy(repository, {
-    get(target, prop, receiver) {
-      if (hiddenMethods.includes(prop)) return undefined;
-      const value = Reflect.get(target, prop, receiver);
-      return typeof value === "function" ? value.bind(target) : value;
-    },
-  });
-}
 
 for (const [name, factory] of Object.entries(factories)) {
   test(`${name} stores quote authorizations`, async () => {

--- a/packages/botkit/src/repository.ts
+++ b/packages/botkit/src/repository.ts
@@ -850,6 +850,10 @@ export class ActorScopedRepository {
   findQuoteAuthorizationReferenceAttribution(
     authorization: URL,
   ): Promise<URL | undefined> {
+    if (
+      typeof this.repository.findQuoteAuthorizationReferenceAttribution !==
+        "function"
+    ) return Promise.resolve(undefined);
     return this.repository.findQuoteAuthorizationReferenceAttribution(
       this.identifier,
       authorization,
@@ -2882,11 +2886,14 @@ export class MemoryCachedRepository implements Repository {
       authorization,
     );
     if (found != null) {
-      const attribution = await this.underlying
-        .findQuoteAuthorizationReferenceAttribution(
-          identifier,
-          authorization,
-        );
+      const attribution =
+        typeof this.underlying.findQuoteAuthorizationReferenceAttribution ===
+            "function"
+          ? await this.underlying.findQuoteAuthorizationReferenceAttribution(
+            identifier,
+            authorization,
+          )
+          : undefined;
       await this.cache.addQuoteAuthorizationReference(
         identifier,
         authorization,
@@ -2900,6 +2907,10 @@ export class MemoryCachedRepository implements Repository {
   async *findQuoteAuthorizationReferenceIdentifiers(
     authorization: URL,
   ): AsyncIterable<string> {
+    if (
+      typeof this.underlying.findQuoteAuthorizationReferenceIdentifiers !==
+        "function"
+    ) return;
     for await (
       const identifier of this.underlying
         .findQuoteAuthorizationReferenceIdentifiers(authorization)
@@ -2909,11 +2920,14 @@ export class MemoryCachedRepository implements Repository {
         authorization,
       );
       if (found != null) {
-        const attribution = await this.underlying
-          .findQuoteAuthorizationReferenceAttribution(
-            identifier,
-            authorization,
-          );
+        const attribution =
+          typeof this.underlying.findQuoteAuthorizationReferenceAttribution ===
+              "function"
+            ? await this.underlying.findQuoteAuthorizationReferenceAttribution(
+              identifier,
+              authorization,
+            )
+            : undefined;
         await this.cache.addQuoteAuthorizationReference(
           identifier,
           authorization,
@@ -2934,16 +2948,17 @@ export class MemoryCachedRepository implements Repository {
       authorization,
     );
     if (cached != null) return cached;
+    if (
+      typeof this.underlying.findQuoteAuthorizationReferenceAttribution !==
+        "function"
+    ) return undefined;
     const found = await this.underlying.findQuoteAuthorizationReference(
       identifier,
       authorization,
     );
     if (found == null) return undefined;
     const attribution = await this.underlying
-      .findQuoteAuthorizationReferenceAttribution(
-        identifier,
-        authorization,
-      );
+      .findQuoteAuthorizationReferenceAttribution(identifier, authorization);
     if (attribution != null) {
       await this.cache.addQuoteAuthorizationReference(
         identifier,

--- a/packages/botkit/src/repository.ts
+++ b/packages/botkit/src/repository.ts
@@ -1021,9 +1021,9 @@ export class KvRepository implements Repository {
    * reusing the repository for another bot, even concurrently, does not
    * adopt the same rows again.  Legacy keys are copied, not moved, and
    * the completion is recorded last, so a partially failed run is simply
-   * retried by the adopter on the next call without data loss.  Followees
-   * are also entered into the reverse lookup index used by
-   * {@link KvRepository.findFollowedBots}.
+   * retried by the adopter on the next call without data loss.  Followees and
+   * quote authorization references are also entered into their reverse lookup
+   * indexes.
    *
    * Calling this method again after a successful migration is a no-op.
    * @param identifier The identifier of the bot actor that adopts the legacy
@@ -1096,6 +1096,25 @@ export class KvRepository implements Repository {
             continue;
           }
           await this.#addToFolloweeIndex(identifier, followeeId);
+        }
+        if (category === "quoteAuthorizationRefs" && rest.length === 1) {
+          let authorization: URL;
+          try {
+            authorization = new URL(rest[0]);
+          } catch (error) {
+            // A malformed legacy key cannot be indexed; storage errors from
+            // the indexing itself must propagate so the done marker is not
+            // written and the adopter retries:
+            logger.warn(
+              "Skipping the malformed legacy quote authorization reference key {authorization}.",
+              { authorization: rest[0], error },
+            );
+            continue;
+          }
+          await this.#addToQuoteAuthorizationReferenceIndex(
+            identifier,
+            authorization,
+          );
         }
       }
     }

--- a/packages/botkit/src/repository.ts
+++ b/packages/botkit/src/repository.ts
@@ -396,6 +396,17 @@ export interface Repository {
   ): Promise<Uuid | undefined>;
 
   /**
+   * Finds bot identifiers whose quote messages depend on a received quote
+   * authorization stamp.
+   * @param authorization The URI of the received quote authorization stamp.
+   * @returns The identifiers of bot actors that reference the stamp.
+   * @since 0.5.0
+   */
+  findQuoteAuthorizationReferenceIdentifiers(
+    authorization: URL,
+  ): AsyncIterable<string>;
+
+  /**
    * Finds the actor that issued a received quote authorization stamp.
    * @param identifier The identifier of the bot actor that owns the message.
    * @param authorization The URI of the received quote authorization stamp.
@@ -989,6 +1000,15 @@ export class KvRepository implements Repository {
       "quoteAuthorizationRefs",
       authorization.href,
     );
+  }
+
+  #quoteAuthorizationReferenceIndexKey(authorization: URL): KvKey {
+    return [
+      ...this.prefix,
+      "index",
+      "quoteAuthorizationRefs",
+      authorization.href,
+    ];
   }
 
   /**
@@ -1831,6 +1851,10 @@ export class KvRepository implements Repository {
         ? messageId
         : { messageId, attribution: attribution.href },
     );
+    await this.#addToQuoteAuthorizationReferenceIndex(
+      identifier,
+      authorization,
+    );
   }
 
   async findQuoteAuthorizationReference(
@@ -1842,6 +1866,15 @@ export class KvRepository implements Repository {
     );
     if (typeof value === "string") return value as Uuid;
     return value?.messageId;
+  }
+
+  async *findQuoteAuthorizationReferenceIdentifiers(
+    authorization: URL,
+  ): AsyncIterable<string> {
+    const identifiers = await this.kv.get<string[]>(
+      this.#quoteAuthorizationReferenceIndexKey(authorization),
+    ) ?? [];
+    for (const identifier of identifiers) yield identifier;
   }
 
   async findQuoteAuthorizationReferenceAttribution(
@@ -1866,6 +1899,10 @@ export class KvRepository implements Repository {
   ): Promise<void> {
     await this.kv.delete(
       this.#quoteAuthorizationReferenceKey(identifier, authorization),
+    );
+    await this.#removeFromQuoteAuthorizationReferenceIndex(
+      identifier,
+      authorization,
     );
   }
 
@@ -1907,6 +1944,48 @@ export class KvRepository implements Repository {
       logger.trace(
         "CAS operation failed, retrying to unindex followee {followeeId} for bot {identifier}.",
         { followeeId: followeeId.href, identifier },
+      );
+    }
+  }
+
+  async #addToQuoteAuthorizationReferenceIndex(
+    identifier: string,
+    authorization: URL,
+  ): Promise<void> {
+    const key = this.#quoteAuthorizationReferenceIndexKey(authorization);
+    while (true) {
+      const prev = await this.kv.get<string[]>(key);
+      if (prev != null && prev.includes(identifier)) return;
+      const next = prev == null ? [identifier] : [...prev, identifier];
+      if (this.kv.cas == null) {
+        await this.kv.set(key, next);
+        return;
+      }
+      if (await this.kv.cas(key, prev, next)) return;
+      logger.trace(
+        "CAS operation failed, retrying to index quote authorization reference {authorization} for bot {identifier}.",
+        { authorization: authorization.href, identifier },
+      );
+    }
+  }
+
+  async #removeFromQuoteAuthorizationReferenceIndex(
+    identifier: string,
+    authorization: URL,
+  ): Promise<void> {
+    const key = this.#quoteAuthorizationReferenceIndexKey(authorization);
+    while (true) {
+      const prev = await this.kv.get<string[]>(key);
+      if (prev == null || !prev.includes(identifier)) return;
+      const next = prev.filter((id) => id !== identifier);
+      if (this.kv.cas == null) {
+        await this.kv.set(key, next);
+        return;
+      }
+      if (await this.kv.cas(key, prev, next)) return;
+      logger.trace(
+        "CAS operation failed, retrying to unindex quote authorization reference {authorization} for bot {identifier}.",
+        { authorization: authorization.href, identifier },
       );
     }
   }
@@ -2380,6 +2459,16 @@ export class MemoryRepository implements Repository {
     );
   }
 
+  async *findQuoteAuthorizationReferenceIdentifiers(
+    authorization: URL,
+  ): AsyncIterable<string> {
+    for (const [identifier, data] of this.#data) {
+      if (data.quoteAuthorizationRefs.has(authorization.href)) {
+        yield identifier;
+      }
+    }
+  }
+
   findQuoteAuthorizationReferenceAttribution(
     identifier: string,
     authorization: URL,
@@ -2787,6 +2876,34 @@ export class MemoryCachedRepository implements Repository {
       );
     }
     return found;
+  }
+
+  async *findQuoteAuthorizationReferenceIdentifiers(
+    authorization: URL,
+  ): AsyncIterable<string> {
+    for await (
+      const identifier of this.underlying
+        .findQuoteAuthorizationReferenceIdentifiers(authorization)
+    ) {
+      const found = await this.underlying.findQuoteAuthorizationReference(
+        identifier,
+        authorization,
+      );
+      if (found != null) {
+        const attribution = await this.underlying
+          .findQuoteAuthorizationReferenceAttribution(
+            identifier,
+            authorization,
+          );
+        await this.cache.addQuoteAuthorizationReference(
+          identifier,
+          authorization,
+          found,
+          attribution,
+        );
+      }
+      yield identifier;
+    }
   }
 
   async findQuoteAuthorizationReferenceAttribution(


### PR DESCRIPTION
Closes #30.


Why this shape
--------------

[FEP-044f] approval has to be checked at the point where a received message is materialized, not only when the activity first arrives. A stamp can disappear or change after the quote was stored, so *packages/botkit/src/message-impl.ts* dereferences and validates the stamp each time it computes `Message.quoteApproved`. The helper in *packages/botkit/src/quote-authorization.ts* keeps the validation rules shared between materialization and incoming approval handling, so the origin, attribution, quote object, and target object checks cannot drift apart.

Self-quotes are treated as approved because they do not need a remote authorization stamp. Everything else is conservative: a missing stamp, a failed fetch, a mismatched `interactingObject`, a mismatched `interactionTarget`, a mismatched `attributedTo`, or a stamp from the wrong origin becomes `false` rather than an exception. That gives event handlers a clear signal without making timeline ingestion brittle.

[FEP-044f]: https://w3id.org/fep/044f


How revocation is routed
------------------------

A deleted quote authorization stamp may be delivered to the shared inbox without addressing the local bot that used it. Routing only through `to` and `cc` would miss that Delete, especially for dynamic bot groups. *packages/botkit/src/instance-impl.ts* therefore asks the repository for every bot identifier that references the deleted stamp URI and resolves those identifiers through the normal instance routing path.

Once a bot receives the Delete, *packages/botkit/src/bot-impl.ts* validates the revoker by origin instead of by exact actor URI. That matches how servers often send administrative Deletes from a same-origin service actor. The original Delete is forwarded before the local quote is stripped, preserving the remote revocation activity for followers first; the local message is then updated without the quote target, and `Bot.onQuoteRevoked` fires after the Update has been sent.


How storage supports routing
----------------------------

The received-stamp reference index is intentionally repository-level rather than actor-scoped. Shared-inbox routing starts before the instance knows which bot should handle the Delete, so the lookup has to answer “which identifiers reference this stamp?” rather than “which message does this one bot reference?”

*packages/botkit/src/repository.ts* adds that reverse lookup for the KV, memory, and memory-cached repositories. *packages/botkit-sqlite/src/mod.ts* and *packages/botkit-postgres/src/mod.ts* add database indexes on the authorization URI so the same query stays cheap for persistent repositories. The existing actor-scoped reference methods still handle per-bot message lookup and cleanup after the route has been resolved.


Validation
----------

The tests exercise the failure modes that matter for federation rather than only the happy path: invalid stamps, legacy quotes without stamps, failed stamp fetches, same-origin service revocations, wrong-origin Deletes, unaddressed shared-inbox Deletes, and dynamic bot group routing. The repository tests cover the new reverse lookup across the in-memory, KV, SQLite, and PostgreSQL implementations.

I ran `mise run test` and `mise run docs:build`. The commit hook also ran `deno check`, `deno lint`, `deno fmt --check`, `hongdown --check`, and `deno publish --dry-run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Message.quoteApproved` to report whether an incoming quote target is approved (or not applicable).
  * Added `onQuoteRevoked` so bots can react when a quote authorization is revoked.
  * Added repository support for reverse-lookup of which bot identifiers depend on a received quote authorization.
* **Bug Fixes**
  * Improved revoked-quote handling: quote targets are stripped and update activities are sent.
  * Fixed delete routing for revoked quote authorizations, including dynamic bot setups.
* **Documentation**
  * Updated quote/quoting event and message documentation for accepted/rejected/revoked behavior.
* **Tests**
  * Expanded coverage for quote approval/revocation and quote-authorization reference indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->