### PR TITLE
Add example of running multiple bots on one server

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -86,6 +86,26 @@ interactions with traditional web applications.
 <!-- hongdown-enable -->
 
 
+Multiple bots on one server
+---------------------------
+
+This example shows how to host multiple bots on a single server using
+`createInstance()`.  The instance owns the shared infrastructure, while each
+bot has its own actor identity and event handlers.  Two bots are created:
+a greet bot that replies to mentions with a friendly message, and an echo
+bot that repeats what you say back to you.
+
+<!-- hongdown-disable -->
+
+::: code-group
+
+<<< @/../examples/multi/multi.ts [multi.ts]
+
+:::
+
+<!-- hongdown-enable -->
+
+
 FediChatBot
 -----------
 

--- a/examples/multi/deno.json
+++ b/examples/multi/deno.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "dev": "deno serve --allow-net --allow-env --watch multi.ts",
+    "prod": "deno serve --allow-net --allow-env multi.ts"
+  }
+}

--- a/examples/multi/multi.ts
+++ b/examples/multi/multi.ts
@@ -1,0 +1,52 @@
+import {
+  createInstance,
+  text,
+} from "@fedify/botkit";
+import { DenoKvMessageQueue, DenoKvStore } from "@fedify/denokv";
+
+const kv = await Deno.openKv();
+
+const instance = createInstance<void>({
+  kv: new DenoKvStore(kv),
+  queue: new DenoKvMessageQueue(kv),
+  behindProxy: true,
+  pages: { color: "blue" },
+});
+
+const greetBot = instance.createBot("greet", {
+  username: "greetbot",
+  name: "Greet Bot",
+  summary:
+    text`A simple greeting bot that replies to mentions, hosted on a multi-bot instance.`,
+  icon: new URL("https://botkit.fedify.dev/favicon-192x192.png"),
+});
+
+greetBot.onFollow = async (session, followRequest) => {
+  await session.publish(
+    text`Thanks for following me, ${followRequest.follower}!`,
+    { visibility: "direct" },
+  );
+};
+
+greetBot.onMention = async (session, message) => {
+  await message.reply(
+    text`Hello, ${message.actor}! Have a great day!`,
+  );
+};
+
+const echoBot = instance.createBot("echo", {
+  username: "echobot",
+  name: "Echo Bot",
+  summary:
+    text`An echo bot that repeats what you say, hosted on a multi-bot instance.`,
+  icon: new URL("https://botkit.fedify.dev/favicon-192x192.png"),
+});
+
+echoBot.onMention = async (session, message) => {
+  if (message.replyTarget != null) return;
+  await message.reply(
+    text`You said: ${message.text}`,
+  );
+};
+
+export default instance;


### PR DESCRIPTION
Issue #15 asked how to run multiple bots on one server, back when botkit only supported a single bot per instance. That changed with #16, which landed createInstance() for hosting multiple bots (shipping in 0.5.0). The docs mentioned createInstance() but didn't have a worked example showing how to wire it up end to end.

Added a complete example under examples/multi/ with two bots on a single Deno KV-backed instance. A greet bot replies to mentions and sends a welcome DM on follow. An echo bot repeats messages back. They share one KV store, one queue, one HTTP handler, showing the pattern anyone would need to replicate.

The examples.md section sits between the OTP auth example and FediChatBot, following the same Setext heading, short description, and hongdown-wrapped code-group block as the existing examples.

Closes #15.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an example for running multiple bots on one server.
  * Included two sample bots: one that sends a greeting and thank-you message, and another that echoes mentions.
  * Added run tasks for local development and production use.
* **Documentation**
  * Expanded the examples guide with setup and usage details for the multi-bot approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->